### PR TITLE
re-querying on map change

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -1,14 +1,5 @@
 import Ember from 'ember';
-// import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
 export default Ember.Controller.extend({
-	// bBox: null,
-	// actions: {
-	// 	getBbox(newBbox) {
-	// 		let bBox = newBbox;
-	// 		this.set('bBox', bBox.toBBoxString());
- //      console.log(this.bBox);
-
-	// 	}
-	// }
+	
 });

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,10 +1,8 @@
 <container-fluid>
-<!-- {{bBox}} -->
   <row>
     <div class="col-sm-12 col-md-3 col-lg-3">    	
 			{{outlet}}
     </div>
-		<!-- {{#map-explorer onMove=(action "getBbox")}}{{/map-explorer}} -->
 	</row>
 </container-fluid>
 

--- a/app/components/map-explorer/component.js
+++ b/app/components/map-explorer/component.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
 	lat: 37.7749,
 	lng: -122.4194,
 	zoom: 12,
-	bBox: null,
+	bbox: null,
 	resetButton: false,
 	testLocation: [37.7749, -122.4194],
 	testLocationTwo: [37.7900, -122.4194],
@@ -13,10 +13,10 @@ export default Ember.Component.extend({
 		iconSize: (20, 20)
 	}),
 	actions: {
-		updateBbox(e) {
-			var newBox = e.target.getBounds();
-			this.set('bBox', newBox.toBBoxString());
-			this.get('getBbox')(newBox);
+		updatebbox(e) {
+			var newbox = e.target.getBounds();
+			this.set('bbox', newbox.toBBoxString());
+			this.get('getbbox')(newbox);
 		}
 	}
 });

--- a/app/components/map-explorer/template.hbs
+++ b/app/components/map-explorer/template.hbs
@@ -1,52 +1,9 @@
 <div id="map">
-  {{#leaflet-map lat=lat lng=lng bBox=bBox zoom=zoom onLoad=(action "updateBbox") onMoveend=(action "updateBbox")}}
+  {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
 		
 		{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
-  	
-  	<!-- {{#marker-layer location=testLocation icon=icon draggable=true}}
-  		<h3>Test Location</h3>
-	      Sample Location<br>
-	      San Francisco
-  	{{/marker-layer}}
-
-	  {{#marker-layer location=testLocationTwo icon=icon}}
-	    <h3>Test Location 2</h3>
-	  {{/marker-layer}} -->
-
-	{{#each models as |model|}}
-  		{{#marker-layer location=toLeafletCoordinates icon=icon draggable=true}}
-  		{{model.onestop_id}}
-  		{{/marker-layer}}
-  	{{/each}}
-
-	<!-- {{#each models as |model|}}
-    	{{#polygon-layer locations=model.geometry.coordinates}}
-	    	<h3>{{model.name}}</h3>
-	  	{{/polygon-layer}}
-    {{/each}} -->
-
-    <!-- {{#each operators as |operator|}} -->
-    <!-- add method on operator model (toLeafletCoordinates) that reverses coordinates -->
-    <!-- Ian suggests: -->
-    <!-- return geometry(['coodrinates']).map(function(coord) {return coord.reverse()}) -->
-	  	<!-- {{#polygon-layer locations=coordinates }}
-
-	  	{{/polygon-layer}} -->
-	  	<!-- {{operator.name}} -->
 	  	
-
-    <!-- {{/each}} -->
-
-
+	
 
 	{{/leaflet-map}}
-	{{bBox}}
 </div>
-<!-- {{#each models as |model|}}
-  	{{#marker-layer location=model.geometry.coordinates icon=icon draggable=true}}
-  	{{/marker-layer}}
-
-
-	<!-- {{detail}} -->
-{{/each}} -->
-

--- a/app/components/test-component/component.js
+++ b/app/components/test-component/component.js
@@ -1,4 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-});

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
-// import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
-
 
 export default Ember.Controller.extend({
-	queryParams: ['bBox'],
-	bBox: null,
+	queryParams: ['bbox'],
+	bbox: null,
+	lat: 37.7749,
+	lng: -122.4194,
+	zoom: 12,
 	actions: {
 		
 	}

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -1,16 +1,18 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-	bBox: null,
+	bbox: null,
 	queryParams: {
-    bBox: {
-      replace: true
+    bbox: {
+      replace: true,
+      refreshModel: true
+
     }
 	},
 
-	model: function(params){
-		return this.store.query('data/transitland/operator', params);
-	}
+	// model: function(params){
+	// 	return this.store.query('data/transitland/operator', params);
+	// }
 
 	// model: function(params){
 	// 	let operator = this.store.query('data/transitland/operator', params);

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -5,21 +5,30 @@
       <div class="toc" role="directory">
         <ul class="nav toc-nav">
             <li class="toc-top-level">
-              {{#link-to 'routes' (query-params bBox=bBox)}}<span>Routes</span>{{/link-to}}
+              {{#link-to 'routes' (query-params bbox=bbox)}}<span>Routes</span>{{/link-to}}
             </li>
          
             <li class="toc-top-level">
-              {{#link-to 'stops' (query-params bBox=bBox)}}<span>Stops</span>{{/link-to}}
+              {{#link-to 'stops' (query-params bbox=bbox)}}<span>Stops</span>{{/link-to}}
             </li>
 
             <li class="toc-top-level">
-              {{#link-to 'operators' (query-params bBox=bBox)}}<span>Operators</span>{{/link-to}}
+              {{#link-to 'operators' (query-params bbox=bbox)}}<span>Operators</span>{{/link-to}}
             </li>
         </ul>
       </div>
    		<button class="btn btn-mapzen-alt">Update results</button>
     </div>
-    {{#map-explorer}}{{/map-explorer}}
+    <div id="map">
+      {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom}}
+        
+        {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+          
+      
+
+      {{/leaflet-map}}
+</div>
+
 
   </div>
 

--- a/app/mixins/map-bbox-route.js
+++ b/app/mixins/map-bbox-route.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
 	queryParams: {
-    bBox: {
+    bbox: {
       replace: true
     }
   }

--- a/app/operators/controller.js
+++ b/app/operators/controller.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
 export default Ember.Controller.extend(mapBboxController, {
-	queryParams: ['bBox'],
-	bBox: null,
+	queryParams: ['bbox'],
+	bbox: null,
 	lat: 37.7749,
 	lng: -122.4194,
 	zoom: 12,
@@ -12,9 +12,9 @@ export default Ember.Controller.extend(mapBboxController, {
 		iconSize: (20, 20)
 	}),
 	actions: {
-		updateBbox(e) {
-			var newBox = e.target.getBounds();
-			this.set('bBox', newBox.toBBoxString());
+		updatebbox(e) {
+			var newbox = e.target.getBounds();
+			this.set('bbox', newbox.toBBoxString());
 		}
 	}	
 });

--- a/app/operators/route.js
+++ b/app/operators/route.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 
 export default Ember.Route.extend(mapBboxRoute, {
-  // bBox: null,
   queryParams: {
-    bBox: {
+    bbox: {
       replace: true
+      refreshModel: true
+
     }
   },
   

--- a/app/operators/template.hbs
+++ b/app/operators/template.hbs
@@ -1,4 +1,4 @@
-{{#link-to 'index' (query-params bBox=bBox)}}<h2>Mobility Explorer</h2>{{/link-to}}
+{{#link-to 'index' (query-params bbox=bbox)}}<h2>Mobility Explorer</h2>{{/link-to}}
 
 <div class="container">
   <div class="row">
@@ -6,10 +6,10 @@
       <div class="toc" role="directory">
         <ul class="nav toc-nav">
             <li class="toc-top-level">
-              {{#link-to 'routes' (query-params bBox=bBox)}}<span>Routes</span>{{/link-to}}
+              {{#link-to 'routes' (query-params bbox=bbox)}}<span>Routes</span>{{/link-to}}
             </li>
             <li class="toc-top-level">
-              {{#link-to 'stops' (query-params bBox=bBox)}}<span>Stops</span>{{/link-to}}
+              {{#link-to 'stops' (query-params bbox=bbox)}}<span>Stops</span>{{/link-to}}
             </li>
             <li class="toc-top-level toc-current">
               <a href="#" class="toc-subnav-toggle">Operators</a>
@@ -33,7 +33,7 @@
     	<button class="btn btn-mapzen-alt" {{action "printBbox"}}>Update results</button>
     </div>
       <div id="map">
-        {{#leaflet-map lat=lat lng=lng bBox=bBox zoom=zoom onLoad=(action "updateBbox") onMoveend=(action "updateBbox")}}
+        {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
           
           {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
           

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
 export default Ember.Controller.extend(mapBboxController, {
-	queryParams: ['bBox'],
-	bBox: null,
+	queryParams: ['bbox'],
+	bbox: null,
 	lat: 37.7749,
 	lng: -122.4194,
 	zoom: 12,
@@ -12,11 +12,11 @@ export default Ember.Controller.extend(mapBboxController, {
 		iconSize: (20, 20)
 	}),
 	actions: {
-    updateBbox(e) {
-			var newBox = e.target.getBounds();
-			this.set('bBox', newBox.toBBoxString());
+    updatebbox(e) {
+			var newbox = e.target.getBounds();
+			this.set('bbox', newbox.toBBoxString());
 		},
-    printBbox(){
+    printbbox(){
       console.log("routes bbox: " + this.bBox);
     }
   }

--- a/app/routes/route.js
+++ b/app/routes/route.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 
 export default Ember.Route.extend(mapBboxRoute, {
-  // bBox: null,
   queryParams: {
-    bBox: {
-      replace: true
+    bbox: {
+      replace: true,
+      refreshModel: true
+
     }
   },
   

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -1,4 +1,4 @@
-{{#link-to 'index' (query-params bBox=bBox)}}<h2>Mobility Explorer</h2>{{/link-to}}
+{{#link-to 'index' (query-params bbox=bbox)}}<h2>Mobility Explorer</h2>{{/link-to}}
 <div class="container">
   <div class="row">
     <div class="col-xs-12 col-md-3">
@@ -36,17 +36,17 @@
 							  </li>
             </li>
             <li class="toc-top-level">
-              {{#link-to 'stops' (query-params bBox=bBox)}}<span>Stops</span>{{/link-to}}
+              {{#link-to 'stops' (query-params bbox=bbox)}}<span>Stops</span>{{/link-to}}
             </li>
             <li class="toc-top-level">
-              {{#link-to 'operators' (query-params bBox=bBox)}}<span>Operators</span>{{/link-to}}
+              {{#link-to 'operators' (query-params bbox=bbox)}}<span>Operators</span>{{/link-to}}
             </li>
         </ul>
       </div>
     	<button class="btn btn-mapzen-alt" {{action "printBbox"}}>Update results</button>
     </div>
     <div id="map">
-		  {{#leaflet-map lat=lat lng=lng bBox=bBox zoom=zoom onLoad=(action "updateBbox") onMoveend=(action "updateBbox")}}
+		  {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
 				
 				{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				

--- a/app/stops/controller.js
+++ b/app/stops/controller.js
@@ -2,19 +2,41 @@ import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
 export default Ember.Controller.extend(mapBboxController, {
-	queryParams: ['bBox'],
-	bBox: null,
+	queryParams: ['bbox'],
+	bbox: null,
 	lat: 37.7749,
 	lng: -122.4194,
 	zoom: 12,
+	bounds: null,
 	icon: L.icon({
 		iconUrl: 'assets/images/stop.png',		
-		iconSize: (10, 10)
+		iconSize: (7, 7)
 	}),
 	actions: {
-		updateBbox(e) {
-			var newBox = e.target.getBounds();
-			this.set('bBox', newBox.toBBoxString());
+		setbbox(e) {
+			var bounds = e.target.getBounds();
+			this.set('bbox', bounds.toBBoxString());
+			let center = e.target.getCenter();
+      let zoom = e.target.getZoom();
+      this.set('bounds', this.get('bbox'));
+      this.set('lat', center.lat);
+      this.set('lng', center.lng);
+      this.set('zoom', zoom);
+			console.log(this.get('bbox'));
+			console.log(this.get('center'));
+			console.log(this.get('zoom'));
+		},
+		updatebbox(e) {
+			var bounds = e.target.getBounds();
+			this.set('bbox', bounds.toBBoxString());
+			let center = e.target.getCenter();
+      let zoom = e.target.getZoom();
+      this.set('bounds', this.get('bbox'));
+      this.set('lat', center.lat);
+      this.set('lng', center.lng);
+      this.set('zoom', zoom);
+			console.log(this.get('bbox'));
+			console.log(this.get('zoom'));
 		}
 	}	
 });

--- a/app/stops/route.js
+++ b/app/stops/route.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 
 export default Ember.Route.extend(mapBboxRoute, {
-  // bBox: null,
   queryParams: {
-    bBox: {
-      replace: true
+    bbox: {
+      replace: true,
+      refreshModel: true
+
     }
   },
   

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -1,11 +1,11 @@
-{{#link-to 'index' (query-params bBox=bBox)}}<h2>Mobility Explorer</h2>{{/link-to}}
+{{#link-to 'index' (query-params bbox=bbox)}}<h2>Mobility Explorer</h2>{{/link-to}}
 <div class="container">
   <div class="row">
     <div class="col-xs-12 col-md-3">
       <div class="toc" role="directory">
         <ul class="nav toc-nav">
           <li class="toc-top-level">
-            {{#link-to 'routes' (query-params bBox=bBox)}}<span>Routes</span>{{/link-to}}
+            {{#link-to 'routes' (query-params bbox=bbox)}}<span>Routes</span>{{/link-to}}
           </li>
           <li class="toc-top-level toc-current">
 					  <a href="#" class="toc-subnav-toggle">Stops</a>
@@ -29,14 +29,14 @@
 					  </ul>
 					</li>
           <li class="toc-top-level">
-            {{#link-to 'operators' (query-params bBox=bBox)}}<span>Operators</span>{{/link-to}}
+            {{#link-to 'operators' (query-params bbox=bbox)}}<span>Operators</span>{{/link-to}}
           </li>
         </ul>
       </div>
     	<button class="btn btn-mapzen-alt" {{action "printBbox"}}>Update results</button>
     </div>
     <div id="map">
-		  {{#leaflet-map lat=lat lng=lng bBox=bBox zoom=zoom onLoad=(action "updateBbox") onMoveend=(action "updateBbox")}}
+		  {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "setbbox") onMoveend=(action "updatebbox")}}
 				
 				{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				


### PR DESCRIPTION
The model now does refresh with a change to the bbox param. The problem was calling the bbox param "bBox" with a capitalized letter--the transitland API didn't not accept this.
closes #25 
