### PR TITLE
If bbox exists, it to set map bounds. If not, use default bounds. Set perPage to false.

### DIFF
--- a/app/data/transitland/adapter.js
+++ b/app/data/transitland/adapter.js
@@ -5,5 +5,21 @@ import ENV from 'mobility-playground/config/environment';
 export default DS.RESTAdapter.extend({
 	host: ENV.transitlandDatastoreHost,
 	namespace: 'api/v1',
-	coalesceFindRequests: true
+	coalesceFindRequests: true,
+	ajaxOptions: function(url, type, options) {
+    var hash = this._super(url, type, options);
+    if (type === 'GET') {
+      let data = {};
+      if (typeof(hash.data) === 'string') {
+        data = JSON.parse(hash.data);
+      } else if (typeof(hash.data) !== "undefined") {
+        data = hash.data;
+      } else {
+        data = {};
+      }
+      data["per_page"] = false;
+      hash.data = data;
+    }
+    return hash;
+	}
 });

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -1,12 +1,54 @@
 import Ember from 'ember';
+import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(mapBboxController, {
 	queryParams: ['bbox'],
 	bbox: null,
-	lat: 37.7749,
-	lng: -122.4194,
-	zoom: 12,
-	actions: {
+	bounds: Ember.computed('bbox', function(){
+		if (this.get('bbox') === null){
+			// -122.54287719726562%2C37.706911598228466%2C-122.29568481445312%2C37.84259697150785
+			var defaultBoundsArray = [];
+			defaultBoundsArray.push([37.706911598228466, -122.54287719726562]);
+			defaultBoundsArray.push([37.84259697150785, -122.29568481445312]);
+			return defaultBoundsArray;
+		} else {
+			var coordinateArray = [];
+			var bboxString = this.get('bbox');
+			var tempArray = [];
+			var boundsArray = [];
+
+			coordinateArray = bboxString.split(',');
+
+			for (var i = 0; i < coordinateArray.length; i++){
+				tempArray.push(parseFloat(coordinateArray[i]));
+			}
 		
+			var arrayOne = [];
+			var arrayTwo = [];
+			arrayOne.push(tempArray[1]);
+			arrayOne.push(tempArray[0]);
+			arrayTwo.push(tempArray[3]);
+			arrayTwo.push(tempArray[2]);
+			boundsArray.push(arrayOne);
+			boundsArray.push(arrayTwo);
+			return boundsArray;
+		}
+	}),
+	icon: L.icon({
+		iconUrl: 'assets/images/marker.png',		
+		iconSize: (20, 20)
+	}),
+	actions: {
+		updatebbox(e) {
+			var newbox = e.target.getBounds();
+			this.set('bbox', newbox.toBBoxString());
+		}
+	}	,
+	bboxExists: function(){
+		// if (this.get('bbox') !== null) {
+		// 	return true;
+		// }
+			return true;
+
 	}
 });

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -1,25 +1,12 @@
 import Ember from 'ember';
+import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 
 export default Ember.Route.extend({
-	bbox: null,
 	queryParams: {
     bbox: {
       replace: true,
       refreshModel: true
 
     }
-	},
-
-	// model: function(params){
-	// 	return this.store.query('data/transitland/operator', params);
-	// }
-
-	// model: function(params){
-	// 	let operator = this.store.query('data/transitland/operator', params);
-	// 	let feed = this.store.query('data/transitland/feed', params);
-	// 	return Ember.RSVP.hash({
-	// 		operator: operator,
-	// 		feed: feed
-	// 	});}
-
+	}
 });

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -20,26 +20,12 @@
    		<button class="btn btn-mapzen-alt">Update results</button>
     </div>
     <div id="map">
-      {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom}}
-        
-        {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
-          
-      
-
-      {{/leaflet-map}}
-</div>
-
-
+        {{#leaflet-map bounds=bounds bbox=bbox onMoveend=(action "updatebbox")}}
+          {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+        {{/leaflet-map}}
+       <!--  {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onMoveend=(action "updatebbox")}}
+          {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+        {{/leaflet-map}} -->
+    </div>
   </div>
-
 </div>
-
-
-
- <!-- {{#side-nav}}{{/side-nav}} -->
-
-
-
-
-
-

--- a/app/mixins/map-bbox-controller.js
+++ b/app/mixins/map-bbox-controller.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-	bBox: null,
-	queryParams: ["bBox"]
+	bbox: null,
+	queryParams: ["bbox"]
 	
 });

--- a/app/operators/controller.js
+++ b/app/operators/controller.js
@@ -4,9 +4,36 @@ import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 export default Ember.Controller.extend(mapBboxController, {
 	queryParams: ['bbox'],
 	bbox: null,
-	lat: 37.7749,
-	lng: -122.4194,
-	zoom: 12,
+	bounds: Ember.computed('bbox', function(){
+		if (this.get('bbox') === null){
+			// -122.54287719726562%2C37.706911598228466%2C-122.29568481445312%2C37.84259697150785
+			var defaultBoundsArray = [];
+			defaultBoundsArray.push([37.706911598228466, -122.54287719726562]);
+			defaultBoundsArray.push([37.84259697150785, -122.29568481445312]);
+			return defaultBoundsArray;
+		} else {
+			var coordinateArray = [];
+			var bboxString = this.get('bbox');
+			var tempArray = [];
+			var boundsArray = [];
+
+			coordinateArray = bboxString.split(',');
+
+			for (var i = 0; i < coordinateArray.length; i++){
+				tempArray.push(parseFloat(coordinateArray[i]));
+			}
+		
+			var arrayOne = [];
+			var arrayTwo = [];
+			arrayOne.push(tempArray[1]);
+			arrayOne.push(tempArray[0]);
+			arrayTwo.push(tempArray[3]);
+			arrayTwo.push(tempArray[2]);
+			boundsArray.push(arrayOne);
+			boundsArray.push(arrayTwo);
+			return boundsArray;
+		}
+	}),
 	icon: L.icon({
 		iconUrl: 'assets/images/marker.png',		
 		iconSize: (20, 20)

--- a/app/operators/route.js
+++ b/app/operators/route.js
@@ -4,7 +4,7 @@ import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 export default Ember.Route.extend(mapBboxRoute, {
   queryParams: {
     bbox: {
-      replace: true
+      replace: true,
       refreshModel: true
 
     }

--- a/app/operators/template.hbs
+++ b/app/operators/template.hbs
@@ -33,7 +33,7 @@
     	<button class="btn btn-mapzen-alt" {{action "printBbox"}}>Update results</button>
     </div>
       <div id="map">
-        {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
+        {{#leaflet-map bounds=bounds bbox=bbox onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
           
           {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
           

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -4,9 +4,36 @@ import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 export default Ember.Controller.extend(mapBboxController, {
 	queryParams: ['bbox'],
 	bbox: null,
-	lat: 37.7749,
-	lng: -122.4194,
-	zoom: 12,
+	bounds: Ember.computed('bbox', function(){
+		if (this.get('bbox') === null){
+			// -122.54287719726562%2C37.706911598228466%2C-122.29568481445312%2C37.84259697150785
+			var defaultBoundsArray = [];
+			defaultBoundsArray.push([37.706911598228466, -122.54287719726562]);
+			defaultBoundsArray.push([37.84259697150785, -122.29568481445312]);
+			return defaultBoundsArray;
+		} else {
+			var coordinateArray = [];
+			var bboxString = this.get('bbox');
+			var tempArray = [];
+			var boundsArray = [];
+
+			coordinateArray = bboxString.split(',');
+
+			for (var i = 0; i < coordinateArray.length; i++){
+				tempArray.push(parseFloat(coordinateArray[i]));
+			}
+		
+			var arrayOne = [];
+			var arrayTwo = [];
+			arrayOne.push(tempArray[1]);
+			arrayOne.push(tempArray[0]);
+			arrayTwo.push(tempArray[3]);
+			arrayTwo.push(tempArray[2]);
+			boundsArray.push(arrayOne);
+			boundsArray.push(arrayTwo);
+			return boundsArray;
+		}
+	}),
 	icon: L.icon({
 		iconUrl: 'assets/images/marker.png',		
 		iconSize: (20, 20)

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -46,7 +46,7 @@
     	<button class="btn btn-mapzen-alt" {{action "printBbox"}}>Update results</button>
     </div>
     <div id="map">
-		  {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
+		  {{#leaflet-map bounds=bounds bbox=bbox onLoad=(action "updatebbox") onMoveend=(action "updatebbox")}}
 				
 				{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				

--- a/app/stops/controller.js
+++ b/app/stops/controller.js
@@ -4,10 +4,36 @@ import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 export default Ember.Controller.extend(mapBboxController, {
 	queryParams: ['bbox'],
 	bbox: null,
-	lat: 37.7749,
-	lng: -122.4194,
-	zoom: 12,
-	bounds: null,
+	bounds: Ember.computed('bbox', function(){
+		if (this.get('bbox') === null){
+			// -122.54287719726562%2C37.706911598228466%2C-122.29568481445312%2C37.84259697150785
+			var defaultBoundsArray = [];
+			defaultBoundsArray.push([37.706911598228466, -122.54287719726562]);
+			defaultBoundsArray.push([37.84259697150785, -122.29568481445312]);
+			return defaultBoundsArray;
+		} else {
+			var coordinateArray = [];
+			var bboxString = this.get('bbox');
+			var tempArray = [];
+			var boundsArray = [];
+
+			coordinateArray = bboxString.split(',');
+
+			for (var i = 0; i < coordinateArray.length; i++){
+				tempArray.push(parseFloat(coordinateArray[i]));
+			}
+		
+			var arrayOne = [];
+			var arrayTwo = [];
+			arrayOne.push(tempArray[1]);
+			arrayOne.push(tempArray[0]);
+			arrayTwo.push(tempArray[3]);
+			arrayTwo.push(tempArray[2]);
+			boundsArray.push(arrayOne);
+			boundsArray.push(arrayTwo);
+			return boundsArray;
+		}
+	}),
 	icon: L.icon({
 		iconUrl: 'assets/images/stop.png',		
 		iconSize: (7, 7)
@@ -16,6 +42,10 @@ export default Ember.Controller.extend(mapBboxController, {
 		setbbox(e) {
 			var bounds = e.target.getBounds();
 			this.set('bbox', bounds.toBBoxString());
+			// if (this.get('bbox') !== null){
+
+			// }
+			
 			let center = e.target.getCenter();
       let zoom = e.target.getZoom();
       this.set('bounds', this.get('bbox'));

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -36,7 +36,7 @@
     	<button class="btn btn-mapzen-alt" {{action "printBbox"}}>Update results</button>
     </div>
     <div id="map">
-		  {{#leaflet-map lat=lat lng=lng bbox=bbox zoom=zoom onLoad=(action "setbbox") onMoveend=(action "updatebbox")}}
+		  {{#leaflet-map bounds=bounds bbox=bbox onLoad=(action "setbbox") onMoveend=(action "updatebbox")}}
 				
 				{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				

--- a/tests/unit/application/adapter-test.js
+++ b/tests/unit/application/adapter-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:application', 'Unit | Adapter | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});


### PR DESCRIPTION
This PR removes the limit on results in the API response. It also adds logic to set the map bounds using the bbox, or in lieu of a bbox, using default bounds. This allows the map bounds to match as you navigate between stop, route, and operator routes.

closes #24 
closes #26 
