### PR TITLE
link to view stops served by operator

### DIFF
--- a/app/components/operator-detail/template.hbs
+++ b/app/components/operator-detail/template.hbs
@@ -18,5 +18,6 @@
 		{{#link-to 'operators' (query-params bbox=bbox onestop_id=operator.onestop_id)}}{{operator.name}}{{/link-to}}<br>
 	{{/each}}	
 {{/if}}
-
-<p>{{#link-to 'routes' (query-params bbox=bbox operated_by=onestop_id) }}View routes served by this operator{{/link-to}}</p>
+<br>
+<p>{{#link-to 'routes' (query-params bbox=bbox operated_by=onestop_id) }}View routes served by this operator{{/link-to}}</p><br>
+<p>{{#link-to 'stops' (query-params bbox=bbox served_by=onestop_id) }}View stops served by this operator{{/link-to}}</p>


### PR DESCRIPTION
Uses query param to link to view stops served by operator.

closes #40 
