### PR TITLE
add query param for route style

### DIFF
--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -1,7 +1,7 @@
 <div class="col-xs-12 col-sm-12 col-md-3">
   <h2>Mobility Explorer</h2>
   <div class="btn-group-vertical" role="group">
-    {{#link-to 'routes' (query-params bbox=bbox onestop_id=null)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
+    {{#link-to 'routes' (query-params bbox=bbox onestop_id=null style_routes_by=null)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
     {{#link-to 'stops' (query-params bbox=bbox onestop_id=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Stops</button>{{/link-to}}
     {{#link-to 'operators' (query-params bbox=bbox onestop_id=null)}}<button class="btn btn-transparent-alt">Operators</button>{{/link-to}}
   </div>

--- a/app/operators/template.hbs
+++ b/app/operators/template.hbs
@@ -1,12 +1,12 @@
 <div class="col-xs-12 col-sm-12 col-md-3 linebreak-text">
   {{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
-  {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
+  {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
   {{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Stops</button>{{/link-to}}
   {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null)}}<button class="btn btn-mapzen-alt">Operators</button>{{/link-to}}
   <div class="expanded-selection">
     {{#if onestop_id}}
       {{#operator-detail bbox=bbox onestop_id=onestop_id operator=selectedOperator operators=model}}{{/operator-detail}}
-      <p>{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null serves=null operated_by=onestop_id  served_by=null) }}View routes served by this operator{{/link-to}}</p><br>
+      <p>{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null serves=null operated_by=onestop_id  served_by=null style_routes_by=null) }}View routes served by this operator{{/link-to}}</p><br>
       <p>{{#link-to 'stops' (query-params bbox=leafletBbox served_by=onestop_id onestop_id=null serves=null operated_by=null isochrone_mode=null) }}View stops served by this operator{{/link-to}}</p>
     {{else}}
       {{#power-select

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
 export default Ember.Controller.extend(mapBboxController, {
-	queryParams: ['bbox', 'onestop_id', 'serves', 'operated_by', 'vehicle_type'],
+	queryParams: ['bbox', 'onestop_id', 'serves', 'operated_by', 'vehicle_type', 'style_routes_by'],
 	bbox: null,
 	leafletBbox: [[37.706911598228466, -122.54287719726562],[37.84259697150785, -122.29568481445312]],
 	queryIsInactive: false,
@@ -10,6 +10,7 @@ export default Ember.Controller.extend(mapBboxController, {
 	serves: null,
 	operated_by: null,
 	vehicle_type: null,
+	style_routes_by: null,
 	selectedRoute: null,
 	place: null,
 	onlyRoute: Ember.computed('onestop_id', function(){
@@ -62,8 +63,12 @@ export default Ember.Controller.extend(mapBboxController, {
 		routes = routes.concat(data.map(function(route){return route;}));
 		return routes;
 	}),
-	routeStyleIsMode: false,
-	routeStyleIsOperator: false,
+	routeStyleIsMode: Ember.computed('style_routes_by', function(){
+		return (this.get('style_routes_by') === 'mode');
+	}),
+	routeStyleIsOperator: Ember.computed('style_routes_by', function(){
+		return (this.get('style_routes_by') === 'operator');
+	}),
 	actions: {
 		updateLeafletBbox(e) {
 			var leafletBounds = e.target.getBounds();
@@ -75,13 +80,12 @@ export default Ember.Controller.extend(mapBboxController, {
 			this.set('bbox', bounds);
 			// this.set('queryIsInactive', true);
 		},
-		styleRoutesMode(){
-			this.toggleProperty('routeStyleIsMode');
-			this.set('routeStyleIsOperator', false);
-		},
-		styleRoutesOperator(){
-			this.toggleProperty('routeStyleIsOperator');
-			this.set('routeStyleIsMode', false);
+		setRouteStyle(style){
+			if (this.get('style_routes_by') === style){
+  			this.set('style_routes_by', null);
+  		} else {
+  			this.set('style_routes_by', style);
+  		}
 		},
 		setRoute(route){
 			var onestop_id = route.get('id');

--- a/app/routes/route.js
+++ b/app/routes/route.js
@@ -4,7 +4,6 @@ import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 export default Ember.Route.extend(mapBboxRoute, {
   queryParams: {
     onestop_id: {
-      // replace: true,
       refreshModel: true
     },
     bbox: {
@@ -19,6 +18,9 @@ export default Ember.Route.extend(mapBboxRoute, {
       refreshModel: true
     },
     vehicle_type: {
+      refreshModel: true
+    },
+    style_routes_by: {
       refreshModel: true
     }
   },

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -1,7 +1,7 @@
 <div class="col-xs-12 col-sm-12 col-md-3 linebreak-text">
 	{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
   
-    {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null)}}<button class="btn btn-mapzen-alt">Routes</button>{{/link-to}}
+    {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null style_routes_by=null)}}<button class="btn btn-mapzen-alt">Routes</button>{{/link-to}}
     <div class="expanded-selection">
 
 		{{#if onestop_id}}
@@ -17,7 +17,7 @@
 				<strong>Operated by:</strong> {{operated_by}}<br>
 
 			  <div class="form-group-header">Style routes by:</div>
-			  <div class="form-group" {{action "styleRoutesMode"}}>
+			  <div class="form-group">
 			  	{{#if routeStyleIsMode}}<input type="checkbox" id="check-1" name="option-one" checked>
 			  	{{else}}<input type="checkbox" id="check-1" name="option-one">{{/if}}
 			    <label for="check-1">Mode</label>
@@ -26,12 +26,12 @@
 		{{else}}
 			<form>
 			  <div class="form-group-header">Style routes by:</div>
-			  <div class="form-group" {{action "styleRoutesMode"}}>
+			  <div class="form-group" {{action "setRouteStyle" "mode"}}>
 			  	{{#if routeStyleIsMode}}<input type="checkbox" id="check-1" name="option-one" checked>
 			  	{{else}}<input type="checkbox" id="check-1" name="option-one">{{/if}}
 			    <label for="check-1">Mode</label>
 			  </div>
-			  <div class="form-group" {{action "styleRoutesOperator"}}>
+			  <div class="form-group" {{action "setRouteStyle" "operator"}}>
 			    {{#if routeStyleIsOperator}}<input type="checkbox" id="check-2" name="option-two" checked>
 			    {{else}}<input type="checkbox" id="check-2" name="option-two">{{/if}}
 			    <label for="check-2">Operator</label>

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -1,11 +1,11 @@
 <div class="col-xs-12 col-sm-12 col-md-3 linebreak-text">
 	{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
-	{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
+	{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
 	{{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=null)}}<button class="btn btn-mapzen-alt">Stops</button>{{/link-to}}
     <div class="expanded-selection">
 			{{#if onestop_id}}
 		  	{{#stop-detail stop=selectedStop bbox=bbox onestop_id=onestop_id stops=model.stops}}{{/stop-detail}}
-		  	<p>{{#link-to 'routes' (query-params serves=onestop_id bbox=bbox onestop_id=null served_by=null operated_by=null) }}View routes serving this stop{{/link-to}}</p>
+		  	<p>{{#link-to 'routes' (query-params serves=onestop_id bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null) }}View routes serving this stop{{/link-to}}</p>
 		  	<form>
 				  <div class="form-group">
 				  	{{#if pedestrianIsochrone}}


### PR DESCRIPTION
Adds a 'style_routes_by' query parameter, to include the optional operator or mode style to the URL for viewing routes. This adds API calls, though, so the toggle between viewing routes styled by operator, styled by mode, or not styled, is slower than when it was not tied to a query parameter.

Closes #94 
