### PR TITLE
Routelinestyle#102

### DIFF
--- a/app/data/transitland/route/model.js
+++ b/app/data/transitland/route/model.js
@@ -16,9 +16,9 @@ var Route = DS.Model.extend({
 	created_at: DS.attr('date'),
 	updated_at: DS.attr('date'),
 	route_stop_patterns_by_onestop_id: DS.attr(),
-	route_path_opacity: 0.5,
+	route_path_opacity: 0.75,
 	route_path_weight: 2.5,
-	default_color: "blue",
+	default_color: "#6ea0a4",
 	
 	location: (function(){
 		var coordinates = this.get('geometry')['coordinates'][0];

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -23,7 +23,7 @@ export default Ember.Controller.extend(mapBboxController, {
 		}
 	}),
 	hoverRoute: null,
-	unstyledColor: "blue",
+	unstyledColor: "#6ea0a4",
 	bounds: Ember.computed('bbox', function(){
 		if (this.get('bbox') === null){
 			var defaultBoundsArray = [];
@@ -101,29 +101,35 @@ export default Ember.Controller.extend(mapBboxController, {
 			this.set('onestop_id', onestop_id);
 			this.set('selectedRoute', route);
 		},
-		selectRoute(route){
-			this.set('selectedRoute', null);
-			route.set('route_path_opacity', 1);
-			route.set('route_path_weight', 3);
-			this.set('hoverRoute', route);
+		selectRoute(e){
+			e.target.bringToFront();
+			e.target.setStyle({
+				"route_path_opacity": 1,
+				"route_path_weight": 2.5,
+				"color":"red"			
+			});
 		},
-		unselectRoute(route){
-			route.set('route_path_opacity', 0.5);
-			route.set('route_path_weight', 1.5);
-			this.set('hoverRoute', null);
+		unselectRoute(e){
+			e.target.setStyle({
+				"route_path_opacity": 1,
+				"route_path_weight": 2.5,
+				"color":"blue"
+			});
 		},
-		selectUnstyledRoute(route){
-			this.set('selectedRoute', null);
-			route.set('route_path_opacity', 1);
-			route.set('route_path_weight', 3);
-			this.set('hoverRoute', route);
-			route.set('default_color', "red");
+		selectUnstyledRoute(e){
+			e.target.bringToFront();
+			e.target.setStyle({
+				"color":"#d4645c",
+				"route_path_opacity": 1,
+				"route_path_weight": 2.5
+			});
 		},
-		unselectUnstyledRoute(route){
-			route.set('route_path_opacity', 0.5);
-			route.set('route_path_weight', 1.5);
-			this.set('hoverRoute', null);
-			route.set('default_color', "blue");
+		unselectUnstyledRoute(e){
+			e.target.setStyle({
+				"color":"#6ea0a4",
+				"route_path_opacity": 0.75,
+				"route_path_weight": 2.5
+			});
 		},
 		setOnestopId(route) {
 			var onestopId = route.id;

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -106,14 +106,12 @@ export default Ember.Controller.extend(mapBboxController, {
 			e.target.setStyle({
 				"route_path_opacity": 1,
 				"route_path_weight": 2.5,
-				"color":"red"			
 			});
 		},
 		unselectRoute(e){
 			e.target.setStyle({
 				"route_path_opacity": 1,
 				"route_path_weight": 2.5,
-				"color":"blue"
 			});
 		},
 		selectUnstyledRoute(e){

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -101,17 +101,17 @@
 			{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				{{#if routeStyleIsMode}}
 					{{#each model as |route|}}
-					  {{#polyline-layer locations=route.location color=route.vehicle_type_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute" route) onMouseout=(action "unselectRoute" route) onClick=(action "setOnestopId" route)}}
+					  {{#polyline-layer locations=route.location color=route.vehicle_type_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
 						{{/polyline-layer}}
 					{{/each}}
 				{{else if routeStyleIsOperator}}
 					{{#each model as |route|}}
-					  {{#polyline-layer locations=route.location color=route.operator_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute" route) onMouseout=(action "unselectRoute" route) onClick=(action "setOnestopId" route)}}
+					  {{#polyline-layer locations=route.location color=route.operator_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
 						{{/polyline-layer}}
 					{{/each}}
 				{{else}}
 					{{#each model as |route|}}
-					  {{#polyline-layer locations=route.location color=route.default_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectUnstyledRoute" route) onMouseout=(action "unselectUnstyledRoute" route) onClick=(action "setOnestopId" route)}}
+					  {{#polyline-layer locations=route.location color=route.default_color weight=route.route_path_weight opacity=route.route_path_opacity onMouseover=(action "selectUnstyledRoute") onMouseout=(action "unselectUnstyledRoute") onClick=(action "setOnestopId" route)}}
 						{{/polyline-layer}}
 					{{/each}}
 				{{/if}}


### PR DESCRIPTION
This PR makes UI improvements for route lines. When viewing multiple route lines, hovering over a route will move that route to the front and change the color (unless the lines are already styled by mode or operator, in which case the route line hovered over is only moved to the front).

Closes #102 
