### PR TITLE
check that served_by isn't null before checking whether a onestopId f…

### DIFF
--- a/app/stops/route.js
+++ b/app/stops/route.js
@@ -67,7 +67,8 @@ export default Ember.Route.extend(mapBboxRoute, {
         var stopLocation = onlyStop.get('geometry.coordinates');
         var mode = stops.get('query.isochrone_mode');
         var route = stops.get('query.served_by');
-        if (route.indexOf('r') === 0) {
+        if (route !== null){
+          if (route.indexOf('r') === 0) {
           console.log("true route: " + route);
           var url = 'https://transit.land/api/v1/routes.geojson?onestop_id=';
           url += route;
@@ -77,6 +78,7 @@ export default Ember.Route.extend(mapBboxRoute, {
             onlyStop: onlyStop,
             servedByRoute: Ember.$.ajax({ url })
           });
+        }
         } else {
           return Ember.RSVP.hash({
             stops: stops,


### PR DESCRIPTION
…or a route

This PR fixes a bug that was causing stop queries to not render on map.

closes #105 
