### PR TITLE
add pedestrian costing option to avoid ferries

### DIFF
--- a/app/stops/route.js
+++ b/app/stops/route.js
@@ -54,6 +54,7 @@ export default Ember.Route.extend(mapBboxRoute, {
         var json = {
           locations: [{"lat":stopLocation[1], "lon":stopLocation[0]}],
           costing: mode,
+          costing_options: {"pedestrian":{"use_ferry":0}},
           contours: [{"time":15},{"time":30},{"time":45},{"time":60}]
         };
         url += escape(JSON.stringify(json));


### PR DESCRIPTION
Adds a costing option for pedestrian to avoid use of ferries. Isochrones for walking distances render more accurately.

Closes #108 
