### PR TITLE
Isochrones improvement#123

### DIFF
--- a/app/stops/controller.js
+++ b/app/stops/controller.js
@@ -70,6 +70,7 @@ export default Ember.Controller.extend(mapBboxController, {
 			this.set('onestop_id', onestopId);
 			this.set('served_by', null);
 			this.set('displayIsochrone', false);
+			this.set('isochrones_mode', null);
 		},
 		searchRepo(term) {
       if (Ember.isBlank(term)) { return []; }

--- a/app/stops/route.js
+++ b/app/stops/route.js
@@ -92,10 +92,16 @@ export default Ember.Route.extend(mapBboxRoute, {
       } else if (stops.get('query.isochrones_mode')){
         var stopLocations = [];
         var isochrones = [];
-        stopLocations = stopLocations.concat(stops.map(function(stop){return stop.get('geometry.coordinates')}))
+        stopLocations = stopLocations.concat(stops.map(function(stop){return stop.get('geometry.coordinates')}));
+
+        // https://valhalla.dev.mapzen.com/isochrone?api_key=valhalla-t_16n1c
+        // &json=%7B%22
+        // locations%22%3A%5B%7B%22lat%22%3A40.41035916448923%2C%22lon%22%3A-76.47994995117189%7D%5D%2C%22
+        // costing%22%3A%22auto%22%2C%22
+        // contours%22%3A%5B%7B%22time%22%3A15%7D%2C%7B%22time%22%3A30%7D%2C%7B%22time%22%3A45%7D%2C%7B%22time%22%3A60%7D%5D%7D
 
         for (var i = 0; i < stopLocations.length; i++){
-          var url = 'https://matrix.mapzen.com/isochrone?api_key=matrix-bHS1xBE&json=';
+          var url = 'https://valhalla.dev.mapzen.com/isochrone?api_key=valhalla-ThKqdPw&json=';
           var mode = 'pedestrian';
           var json = {
             locations: [{"lat":stopLocations[i][1], "lon":stopLocations[i][0]}],

--- a/app/stops/route.js
+++ b/app/stops/route.js
@@ -94,12 +94,6 @@ export default Ember.Route.extend(mapBboxRoute, {
         var isochrones = [];
         stopLocations = stopLocations.concat(stops.map(function(stop){return stop.get('geometry.coordinates')}));
 
-        // https://valhalla.dev.mapzen.com/isochrone?api_key=valhalla-t_16n1c
-        // &json=%7B%22
-        // locations%22%3A%5B%7B%22lat%22%3A40.41035916448923%2C%22lon%22%3A-76.47994995117189%7D%5D%2C%22
-        // costing%22%3A%22auto%22%2C%22
-        // contours%22%3A%5B%7B%22time%22%3A15%7D%2C%7B%22time%22%3A30%7D%2C%7B%22time%22%3A45%7D%2C%7B%22time%22%3A60%7D%5D%7D
-
         for (var i = 0; i < stopLocations.length; i++){
           var url = 'https://valhalla.dev.mapzen.com/isochrone?api_key=valhalla-ThKqdPw&json=';
           var mode = 'pedestrian';

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -81,15 +81,12 @@
 				</form>
 			{{/if}}
 			<form>
-				<div class="form-group-header">Show isochrones for:</div>
-				<div class="form-group">
-			  	{{#if isochrones_mode}}
-			  		<input type="checkbox" id="check-1" name="option-two" checked {{action "setIsochronesMode"}}>
-			  	{{else}}
-			  		<input type="checkbox" id="check-1" name="option-two" unchecked {{action "setIsochronesMode"}}>
-			  	{{/if}}
-			    <label for="check-2">Walking</label>
-				</div>
+		  	{{#if isochrones_mode}}
+		  		<input type="checkbox" id="check-1" name="option-two" checked {{action "setIsochronesMode"}}>
+		  	{{else}}
+		  		<input type="checkbox" id="check-1" name="option-two" unchecked {{action "setIsochronesMode"}}>
+		  	{{/if}}
+	    	<label for="check-2">Areas within a 15-minute walk of stops</label>
 			</form>
 			{{#if onestop_id}}
 				{{else if hoverStop}}
@@ -98,7 +95,7 @@
 						<p class="caption">Click the stop for more information</p>
 					</div>
 				{{else}}
-		    		<p class="caption">Hover on a stop for information</p>
+		    		<p class="caption">Hover over a stop for information</p>
 		    		{{#if mapMoved}}
 	    				<button class="btn btn-mapzen" {{action "updatebbox"}}>Redo search in map area</button>
 	  				{{/if}}
@@ -150,7 +147,7 @@
 			{{#if isochrones_mode}}
 				{{#each model.isochrones as |isochrone|}}
 					{{#each isochrone.features as |feature|}}
-				  	{{#geojson-layer geoJSON=feature fillColor=feature.properties.fill weight=1 color=feature.properties.fill fillOpacity=feature.properties.fill-opacity}}
+				  	{{#geojson-layer geoJSON=feature fillColor=feature.properties.fill weight=1 color=false fillOpacity=feature.properties.fill-opacity}}
 				  	{{/geojson-layer}}
 				  {{/each}}
 				{{/each}}

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -80,14 +80,16 @@
 				  </div>
 				</form>
 			{{/if}}
-			<form>
-		  	{{#if isochrones_mode}}
-		  		<input type="checkbox" id="check-1" name="option-two" checked {{action "setIsochronesMode"}}>
-		  	{{else}}
-		  		<input type="checkbox" id="check-1" name="option-two" unchecked {{action "setIsochronesMode"}}>
-		  	{{/if}}
-	    	<label for="check-2">Areas within a 15-minute walk of stops</label>
-			</form>
+			{{#unless onestop_id}}
+				<form>
+			  	{{#if isochrones_mode}}
+			  		<input type="checkbox" id="check-1" name="option-two" checked {{action "setIsochronesMode"}}>
+			  	{{else}}
+			  		<input type="checkbox" id="check-1" name="option-two" unchecked {{action "setIsochronesMode"}}>
+			  	{{/if}}
+		    	<label for="check-2">Areas within a 15-minute walk of stops</label>
+				</form>
+			{{/unless}}
 			{{#if onestop_id}}
 				{{else if hoverStop}}
 					<div class="hover-detail">


### PR DESCRIPTION
Improves ability to view walksheds around a number of transit stops at once (eg viewing areas within a 15-minute walk of a BART station). This is currently slow when viewing isochrones for a large number of stops.

Closes #123 
