### PR TITLE
Hover info#129

### DIFF
--- a/app/data/transitland/route/model.js
+++ b/app/data/transitland/route/model.js
@@ -19,24 +19,13 @@ var Route = DS.Model.extend({
 	route_path_opacity: 0.75,
 	route_path_weight: 2.5,
 	default_color: "#6ea0a4",
-	
-	location: (function(){
-		var coordinates = this.get('geometry')['coordinates'][0];
-		var coordinatesLength = coordinates.length;
-		var reversedCoordArray = [];
-		for (var i = 0; i < coordinatesLength; i++){
-			var tempCoord = null;
-			var lat = this.get('geometry')['coordinates'][0][i][0];
-			var lon = this.get('geometry')['coordinates'][0][i][1];
-			tempCoord = lat;
-			lat = lon;
-			lon = tempCoord;
-			var coordArray = [];
-			coordArray.push(lat);
-			coordArray.push(lon);
-			reversedCoordArray.push(coordArray);
+	as_geojson: (function(){
+		return {
+			type: "Feature",
+			geometry: this.get('geometry'),
+			properties: {},
+			id: this.onestop_id
 		}
-		return reversedCoordArray;
 	}).property('geometry'),
 	operator_color: (function(){
 		var str = this.get('operated_by_onestop_id');

--- a/app/route-stop-patterns/route.js
+++ b/app/route-stop-patterns/route.js
@@ -37,11 +37,13 @@ export default Ember.Route.extend(mapBboxRoute, {
 
     var route_stop_patterns = this.store.query('data/transitland/route_stop_pattern', params);
     var url = 'https://transit.land/api/v1/routes.geojson?onestop_id=' + params.traversed_by;
-    var traversedByRoute = Ember.$.ajax({ url });
+    var traversedByRoute = this.store.query('data/transitland/route', {onestop_id: params.traversed_by});
+    var stopsServedByRoute = this.store.query('data/transitland/stop', {served_by: params.traversed_by});
 
     return Ember.RSVP.hash({
       route_stop_patterns: route_stop_patterns,
-      traversedByRoute: traversedByRoute
+      traversedByRoute: traversedByRoute,
+      stopsServedByRoute: stopsServedByRoute
     });
   }
 });

--- a/app/route-stop-patterns/template.hbs
+++ b/app/route-stop-patterns/template.hbs
@@ -5,15 +5,15 @@
   
   <div class="expanded-selection">
 
-			{{#each model.traversedByRoute.features as |route|}}
-	  		{{#route-detail bbox=bbox onestop_id=route.properties.onestop_id route=route.properties}}{{/route-detail}}
+			{{#each model.traversedByRoute as |route|}}
+	  		{{#route-detail bbox=bbox onestop_id=route.onestop_id route=route}}{{/route-detail}}
   		{{/each}}
 			<br>
 
 			<div class="form-group">
 		  	{{#if displayStops}}<input type="checkbox" id="check-1" name="option-one" checked {{action "displayStops"}}>
-		  	{{else}}<input type="checkbox" id="check-1" name="option-one" disabled {{action "displayStops"}}>{{/if}}
-		    <label for="check-1">Show stops served by route (*work in progress*)</label>
+		  	{{else}}<input type="checkbox" id="check-1" name="option-one" {{action "displayStops"}}>{{/if}}
+		    <label for="check-1">Show stops served by route</label>
 		  </div>
 
   		  <div>
@@ -54,19 +54,22 @@
 		{{#leaflet-map bounds=leafletBbox onMoveend=(action "updateLeafletBbox") onDragend=(action "updateMapMoved") onMouseover=(action "mouseOver") onZoomend=(action "updateMapMoved")}}
 			{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}	
 				
-				{{#each model.traversedByRoute.features as |route|}}
-					{{#geojson-layer geoJSON=route color="#6ea0a4" opacity=1 weight=2}}
+				{{#each model.traversedByRoute as |route|}}
+					{{#geojson-layer geoJSON=route.as_geojson color="#6ea0a4" opacity=1 weight=2}}
 					{{/geojson-layer}}
 				{{/each}}
 
-				<!-- {{#each selectedRsp as |rsp|}}
-					  {{#polyline-layer locations=rsp.location color="red"}}
+				{{#each model.route_stop_patterns as |rsp|}}
+					  {{#polyline-layer locations=rsp.location color=rsp.default_color weight=rsp.path_weight opacity=rsp.path_opacity}}
 						{{/polyline-layer}}
-				{{/each}} -->
-					{{#each model.route_stop_patterns as |rsp|}}
-						  {{#polyline-layer locations=rsp.location color=rsp.default_color weight=rsp.path_weight opacity=rsp.path_opacity}}
-							{{/polyline-layer}}
-					{{/each}}
+				{{/each}}
+
+				{{#if displayStops}}
+					{{#each model.stopsServedByRoute as |stop|}}
+			  		{{#marker-layer location=stop.location icon=stop.icon draggable=false riseOnHover=true riseOffset=1000}}
+			  		{{/marker-layer}}
+		  		{{/each}}
+		  	{{/if}}
 		
 		{{/leaflet-map}}
 	</div>

--- a/app/route-stop-patterns/template.hbs
+++ b/app/route-stop-patterns/template.hbs
@@ -66,7 +66,7 @@
 
 				{{#if displayStops}}
 					{{#each model.stopsServedByRoute as |stop|}}
-			  		{{#marker-layer location=stop.location icon=stop.icon draggable=false riseOnHover=true riseOffset=1000}}
+			  		{{#marker-layer location=stop.location icon=stop.stop_icon draggable=false riseOnHover=true riseOffset=1000}}
 			  		{{/marker-layer}}
 		  		{{/each}}
 		  	{{/if}}

--- a/app/route-stop-patterns/template.hbs
+++ b/app/route-stop-patterns/template.hbs
@@ -55,7 +55,7 @@
 			{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}	
 				
 				{{#each model.traversedByRoute as |route|}}
-					{{#geojson-layer geoJSON=route.as_geojson color="#6ea0a4" opacity=1 weight=2}}
+					{{#geojson-layer geoJSON=route.as_geojson color="#6ea0a4" opacity=1 weight=2 clickable=false}}
 					{{/geojson-layer}}
 				{{/each}}
 

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -122,14 +122,14 @@ export default Ember.Controller.extend({
 		selectRoute(e){
 			e.target.bringToFront();
 			e.target.setStyle({
-				"route_path_opacity": 1,
-				"route_path_weight": 2.5,
+				"opacity": 1,
+				"weight": 3,
 			});
 		},
 		unselectRoute(e){
 			e.target.setStyle({
-				"route_path_opacity": 1,
-				"route_path_weight": 2.5,
+				"opacity": 1,
+				"weight": 2.5,
 			});
 		},
 		selectUnstyledRoute(e){
@@ -143,8 +143,8 @@ export default Ember.Controller.extend({
 		unselectUnstyledRoute(e){
 			e.target.setStyle({
 				"color":"#6ea0a4",
-				"route_path_opacity": 0.75,
-				"route_path_weight": 2.5
+				"opacity": 0.75,
+				"weight": 2.5
 			});
 		},
 		setOnestopId: function(route) {

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -139,6 +139,7 @@ export default Ember.Controller.extend({
 				"opacity": 1,
 				"weight": 3
 			});
+			// this.set('hoverRoute');
 		},
 		unselectUnstyledRoute(e){
 			e.target.setStyle({

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -139,7 +139,6 @@ export default Ember.Controller.extend({
 				"opacity": 1,
 				"weight": 3
 			});
-			this.set('hoverRoute', )
 		},
 		unselectUnstyledRoute(e){
 			e.target.setStyle({

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -139,6 +139,7 @@ export default Ember.Controller.extend({
 				"opacity": 1,
 				"weight": 3
 			});
+			this.set('hoverRoute', )
 		},
 		unselectUnstyledRoute(e){
 			e.target.setStyle({
@@ -168,7 +169,6 @@ export default Ember.Controller.extend({
       return Ember.$.ajax({ url }).then(json => json.features);
     },
     displayStops: function(){
-  		// debugger;
   		if (this.get('displayStops') === false){
   			if (this.model.stops.features.get('firstObject').icon){
     			this.set('displayStops', true);
@@ -194,10 +194,6 @@ export default Ember.Controller.extend({
 			} else {
     		this.set('displayStops', false);
     	}
-
-				
-			
-		
     },
     setRouteStopPattern: function(selected){
     	this.set('routeStopPattern', selected);

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -136,8 +136,8 @@ export default Ember.Controller.extend({
 			e.target.bringToFront();
 			e.target.setStyle({
 				"color":"#d4645c",
-				"route_path_opacity": 1,
-				"route_path_weight": 2.5
+				"opacity": 1,
+				"weight": 3
 			});
 		},
 		unselectUnstyledRoute(e){

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -113,13 +113,13 @@
 			{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				{{#if routeStyleIsMode}}
 					{{#each model.routes as |route|}}
-					  {{#polyline-layer locations=route.as_geojson color=route.vehicle_type_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
-						{{/polyline-layer}}
+					  {{#geojson-layer geoJSON=route.as_geojson color=route.vehicle_type_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
+						{{/geojson-layer}}
 					{{/each}}
 				{{else if routeStyleIsOperator}}
 					{{#each model.routes as |route|}}
-					  {{#polyline-layer locations=route.as_geojson color=route.operator_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
-						{{/polyline-layer}}
+					  {{#geojson-layer geoJSON=route.as_geojson color=route.operator_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
+						{{/geojson-layer}}
 					{{/each}}
 				{{else}}
 					{{#each model.routes as |route|}}

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -123,8 +123,11 @@
 					{{/each}}
 				{{else}}
 					{{#each model.routes as |route|}}
-						  {{#polyline-layer locations=route.location color=route.default_color weight=route.route_path_weight opacity=route.route_path_opacity onMouseover=(action "selectUnstyledRoute") onMouseout=(action "unselectUnstyledRoute") onClick=(action "setOnestopId" route)}}
-							{{/polyline-layer}}
+						  
+
+							{{#geojson-layer geoJSON=route.as_geojson color=route.default_color weight=route.route_path_weight opacity=route.route_path_opacity onMouseover=(action "selectUnstyledRoute") onMouseout=(action "unselectUnstyledRoute") onClick=(action "setOnestopId" route)}}
+							{{/geojson-layer}}
+
 					{{/each}}
 				{{/if}}
 				{{#if displayStops}}

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -113,21 +113,18 @@
 			{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 				{{#if routeStyleIsMode}}
 					{{#each model.routes as |route|}}
-					  {{#polyline-layer locations=route.location color=route.vehicle_type_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
+					  {{#polyline-layer locations=route.as_geojson color=route.vehicle_type_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
 						{{/polyline-layer}}
 					{{/each}}
 				{{else if routeStyleIsOperator}}
 					{{#each model.routes as |route|}}
-					  {{#polyline-layer locations=route.location color=route.operator_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
+					  {{#polyline-layer locations=route.as_geojson color=route.operator_color weight=route.route_path_weight opacity=route.route_path_opacity riseOnHover=true onMouseover=(action "selectRoute") onMouseout=(action "unselectRoute") onClick=(action "setOnestopId" route)}}
 						{{/polyline-layer}}
 					{{/each}}
 				{{else}}
 					{{#each model.routes as |route|}}
-						  
-
 							{{#geojson-layer geoJSON=route.as_geojson color=route.default_color weight=route.route_path_weight opacity=route.route_path_opacity onMouseover=(action "selectUnstyledRoute") onMouseout=(action "unselectUnstyledRoute") onClick=(action "setOnestopId" route)}}
 							{{/geojson-layer}}
-
 					{{/each}}
 				{{/if}}
 				{{#if displayStops}}

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -85,7 +85,7 @@
 				<p class="caption">Click the route line for more information</p>
 			</div>
 		{{else}}
-			<p class="caption">Hover on the route line for information</p>
+			<!-- <p class="caption">Hover on the route line for information</p> -->
 			{{#if mapMoved}}
     		<button class="btn btn-mapzen" {{action "updatebbox"}}>Redo search in map area</button>
   		{{/if}}


### PR DESCRIPTION
This resolves the issue where a single segment(RSP) would be rendered rather than all segments for a route. It also repairs the operator and mode style rendering. This does not resolve the hover info issue, which will be tackled in a separate branch.
- [x] Render all segments of route lines
- [x] Render mode and operator styles

Closes #129 
