### PR TITLE
Rsp style#141

### DIFF
--- a/app/data/transitland/route-stop-pattern/model.js
+++ b/app/data/transitland/route-stop-pattern/model.js
@@ -22,7 +22,6 @@ var Route_stop_pattern = DS.Model.extend({
 	path_opacity: 0,
 	path_weight: 3,
 	is_selected: false,
-
 	location: (function(){
 		var coordinates = this.get('geometry')['coordinates'];
 		var coordinatesLength = coordinates.length;
@@ -40,33 +39,6 @@ var Route_stop_pattern = DS.Model.extend({
 				reversedCoordArray.push(coordArray);
 		}
 		return reversedCoordArray;
-	}).property('geometry'),
-	rsp__as_geojson_with_outline: (function(){
-		return {
-			type: "FeatureCollection",
-			features: [
-				{
-					type: "Feature",
-					geometry: this.get('geometry'),
-					properties: {
-						color: "#444444",
-						weight: 5,
-						opacity: 1
-					},
-					id: this.onestop_id,
-					onestop_id: this.get('onestop_id'),
-				},
-				{
-					type: "Feature",
-					geometry: this.get('geometry'),
-					properties: {
-						color: "yellow",
-						weight: 3,
-						opacity: 1
-					},
-				},
-			]
-		}
 	}).property('geometry'),
 });
 

--- a/app/data/transitland/route/model.js
+++ b/app/data/transitland/route/model.js
@@ -16,8 +16,8 @@ var Route = DS.Model.extend({
 	created_at: DS.attr('date'),
 	updated_at: DS.attr('date'),
 	route_stop_patterns_by_onestop_id: DS.attr(),
-	route_path_opacity: 0.75,
-	route_path_weight: 2.5,
+	route_path_opacity: 1,
+	route_path_weight: 3,
 	vehicle_type_color: {
 		'bus' : '#8dd3c7',
 		'rail' : '#b3de69',
@@ -36,7 +36,7 @@ var Route = DS.Model.extend({
 					geometry: this.get('geometry'),
 					properties: {
 						color: "#444444",
-						weight: 0,
+						weight: 5,
 						opacity: 0
 					},
 					id: this.onestop_id,
@@ -47,7 +47,7 @@ var Route = DS.Model.extend({
 					geometry: this.get('geometry'),
 					properties: {
 						color: this.get('default_color'),
-						weight: 2.5,
+						weight: 3,
 						opacity: 1
 					},
 				},
@@ -179,7 +179,7 @@ var Route = DS.Model.extend({
 					type: "Feature",
 					geometry: this.get('geometry'),
 					properties: {
-						color: borderColor,
+						color: "#222222",
 						weight: 5,
 						opacity: 0
 					},

--- a/app/route-stop-patterns/template.hbs
+++ b/app/route-stop-patterns/template.hbs
@@ -60,13 +60,13 @@
 				{{/each}}
 
 				{{#each model.route_stop_patterns as |rsp|}}
-					  {{#polyline-layer locations=rsp.location color=rsp.default_color weight=rsp.path_weight opacity=rsp.path_opacity}}
+					  {{#polyline-layer locations=rsp.location color=rsp.default_color weight=rsp.path_weight opacity=rsp.path_opacity clickable=false}}
 						{{/polyline-layer}}
 				{{/each}}
 
 				{{#if displayStops}}
 					{{#each model.stopsServedByRoute as |stop|}}
-			  		{{#marker-layer location=stop.location icon=stop.stop_icon draggable=false riseOnHover=true riseOffset=1000}}
+			  		{{#marker-layer location=stop.location icon=stop.stop_icon draggable=false clickable=false riseOnHover=true riseOffset=1000}}
 			  		{{/marker-layer}}
 		  		{{/each}}
 		  	{{/if}}

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -140,9 +140,7 @@ export default Ember.Controller.extend({
 			layer.originalStyle = feature.properties;
 
 			if (this.get('onestop_id')){
-				layer.setStyle({
-					"opacity": 1,
-				});
+				layer.eachLayer(function(layer){layer.setStyle({"opacity":1})})
 			}
 		},
 		unselectRoute(e){


### PR DESCRIPTION
Sets rsp's to be unclickable and fixes a single-route view border rendering issue.

Closes #141 
