### PR TITLE
isochrone request formatted to accept departure time

### DIFF
--- a/app/isochrones/controller.js
+++ b/app/isochrones/controller.js
@@ -2,13 +2,14 @@ import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 
 export default Ember.Controller.extend(mapBboxController, {
-	queryParams: ['onestop_id', 'isochrone_mode', 'pin'],
+	queryParams: ['onestop_id', 'isochrone_mode', 'pin', 'departure_time'],
 	bbox: null,
 	leafletBbox: null,
   leafletBounds: [[37.706911598228466, -122.54287719726562],[37.84259697150785, -122.29568481445312]],
   isochrone_mode: null,
   pin: null,
   onestop_id: null,
+  departure_time: null,
   pinLocation: Ember.computed('pin', function(){
     if (typeof(this.get('pin'))==="string"){
       var pinArray = this.get('pin').split(',');
@@ -96,6 +97,7 @@ export default Ember.Controller.extend(mapBboxController, {
       this.set('isochrone_mode', null);
     },
     setIsochroneMode: function(mode){
+      this.set('departure_time', null);
       if (this.get('isochrone_mode') === mode){
         this.set('isochrone_mode', null);
       } else {
@@ -103,7 +105,23 @@ export default Ember.Controller.extend(mapBboxController, {
       }
     },
     change(date){
-			console.log('date: ' + date);
+
+      // This is the local date and time at the location.
+      // type:
+      // 0 - Current departure time.
+      // 1 - Specified departure time
+      // 2 - Specified arrival time. Not yet implemented for multimodal costing method.
+      
+      // value:
+      // the date and time is specified in ISO 8601 format (YYYY-MM-DDThh:mm) in 
+      // the local time zone of departure or arrival. For example "2016-07-03T08:06"
+      // ISO 8601 uses the 24-hour clock system. 
+      // A single point in time can be represented by concatenating a complete date expression, 
+      // the letter T as a delimiter, and a valid time expression. For example, "2007-04-05T14:30".
+			
+
+      var newDepartureTime = date.toISOString().slice(0,16);
+      this.set('departure_time', newDepartureTime);
 		},
   }
 });

--- a/app/isochrones/route.js
+++ b/app/isochrones/route.js
@@ -14,6 +14,10 @@ export default Ember.Route.extend(setLoading, {
     pin: {
       replace: true,
       refreshModel: true
+    },
+    departure_time: {
+    	replace: true,
+    	refreshModel: true
     }
   },
 	setupController: function (controller, model) {
@@ -67,9 +71,14 @@ export default Ember.Route.extend(setLoading, {
 	      costing_options: {"pedestrian":{"use_ferry":0}},
 	      contours: [{"time":15},{"time":30},{"time":45},{"time":60}],
 	    };
+
 	    if (json.costing === "multimodal"){
 	      json.denoise = .1;
 	    }
+	    if (params.departure_time){
+	    	json.date_time = {"type": 1, "value": params.departure_time};
+	    }
+
 	    url += escape(JSON.stringify(json));
 	    return Ember.RSVP.hash({
 	      url: url,

--- a/app/isochrones/template.hbs
+++ b/app/isochrones/template.hbs
@@ -114,7 +114,7 @@
 		{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null isochrone_mode=null pin=pin)}}<button class="btn btn-transparent-alt">Routes</button>{{/link-to}}
 		{{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin isochrone_mode=null)}}<button class="btn btn-transparent-alt">Stops</button>{{/link-to}}
 		{{#link-to 'operators' (query-params bbox=bbox pin=pin onestop_id=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Operators</button>{{/link-to}}
-	  {{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=isochrone_mode pin=pin)}}<button class="btn btn-mapzen-alt">Isochrones</button>{{/link-to}}
+	  {{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=isochrone_mode pin=pin departure_time=null)}}<button class="btn btn-mapzen-alt">Isochrones</button>{{/link-to}}
 	  <div class="expanded-selection">
 	    <form>
 				<div class="isochrone-detail">


### PR DESCRIPTION
Adds timepicker to set the departure time for the isochrone request. (Transit isochrones differ by the time of departure. The request defaults to the current time.)

closes #210 