### PR TITLE
Inline context#219

### DIFF
--- a/app/components/text-box/component.js
+++ b/app/components/text-box/component.js
@@ -3,7 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
 	route: null,
 	textOptions: {
-			'index' : 'Learn about multimodal transportation around the world. Search for a place or browse the map, and use the buttons to view transit routes, stops, and operators.',
+			// 'index' : 'Learn about multimodal transportation around the world. Search for a place or browse the map, and use the buttons to view transit routes, stops, and operators.',
+			'index' : 'There are so many ways to get from A to B! Use Mapzen Mobility Explorer to understand transportation networks around the world. Find a place using the search box or browse the map. Use the buttons below to start exploring. Mass-transit data comes from [Transitland]. Pedestrian, bicycle, and auto data comes from [OpenStreetMap]. Analysis is powered by [Mapzen Mobility services] and search is powered by [Mapzen Search].',
 			'routes' : '',
 			'route-stop-patterns' : '',
 			'stops' : '',

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -66,8 +66,10 @@
     </div>
     <h2>Mobility Explorer</h2>
     {{text-box route="index"}}
-    <h4>Data</h4>
-    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+    <!-- <h4>Fixed route transit</h4> -->
+    <!-- <h4>Public transit network</h4> -->
+    <h4>Visualize public transit networks</h4>
+    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Transitland highlights the connections that exist between transit datasets</caption>
     <div class="btn-group-vertical" role="group" >
 
       {{#link-to 'routes' (query-params bbox=bbox onestop_id=null operated_by=null pin=pin style_routes_by=null pin=pin serves=null)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
@@ -76,8 +78,15 @@
       {{#link-to 'operators' (query-params bbox=bbox pin=pin onestop_id=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}
     </div>
     <hr class="sidebar-hr">
-    <h4>Services</h4>
-    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+    <!-- <h4>Access analysis</h4>
+    <h4>Accessibility</h4> -->
+    <h4>Analyze access</h4>
+
+    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">
+        <!-- Use Mapzen Mobility services to see how public transit, driving, bicycling, and walking options shape our ability to get around.  -->
+        See how public transit, driving, bicycling, and walking options shape our ability to get around.
+        <!-- Analysis is powered by Mapzen Mobility services, using data from Transitland and OpenStreetMap. -->
+    </caption>
       <div class="btn-group-vertical" role="group" >
       {{#link-to 'isochrones' (query-params bbox=bbox pin=pin onestop_id=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
     </div>
@@ -100,7 +109,7 @@
                 {{#power-select
                   search=(action "searchRepo")
                   selected=place
-                  placeholder="Search for location..."
+                  placeholder="Find a place using Mapzen Search..."
                   onchange=(action "setPlace")
                   onclose=(action "clearPlace")
                   as |repo|

--- a/app/isochrones/template.hbs
+++ b/app/isochrones/template.hbs
@@ -74,7 +74,8 @@
 					  		</div>
 					  	{{/if}}
 					  {{else}}
-					  	<p class="caption">Choose a starting point by clicking on the map or searching for a location...</p>
+					  	<p class="caption">See the distance you can travel from a particular point at various time intervals.</p>
+					  	<p class="caption">Start by clicking on the map or searching for a location...</p>
 					  {{/if}}
 					</div>
 				</form>
@@ -205,7 +206,8 @@
 					  		</div>
 					  	{{/if}}
 					  {{else}}
-					  	<p class="caption">Choose a starting point by clicking on the map or searching for a location...</p>
+					  	<p class="caption">See the distance you can travel from a particular point at various time intervals.</p>
+					  	<p class="caption">Start by clicking on the map or searching for a location...</p>
 					  {{/if}}
 					</div>
 				</form>

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -32,7 +32,7 @@
 								  
 								  <row>
 								  	<div class="form-group-header sidebar-header col-md-10">{{#link-to 'route-stop-patterns' (query-params bbox=bbox traversed_by=onestop_id onestop_id=null operated_by=null serves=null served_by=onestop_id vehicle_type=null pin=pin isochrone_mode=null)}}Show route stop patterns{{/link-to}}</div>
-								  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+								  	<div tooltip="View the unique combinations of shape lines for trips and stops along this route." class="col-md-2"><div class="fa fa-question-circle"></div></div>
 								  </row>
 								  <br>
 							  
@@ -307,13 +307,11 @@
 				    <label for="check-1">Show stops served by route</label>
 				  </div>
 				  
-				  <!-- <row>
+				  <row>
 				  	<div class="form-group-header sidebar-header col-md-10">{{#link-to 'route-stop-patterns' (query-params bbox=bbox traversed_by=onestop_id onestop_id=null operated_by=null serves=null served_by=onestop_id vehicle_type=null pin=pin isochrone_mode=null)}}Show route stop patterns{{/link-to}}</div>
-				  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+				  	<div tooltip="View the unique combinations of shape lines for trips and stops along this route." class="col-md-2"><div class="fa fa-question-circle"></div></div>
 				  </row>
-					<br> -->
-
-			  
+					<br>			  
 				{{else if operated_by}}
 					{{#power-select
 			      options=routes
@@ -473,7 +471,7 @@
 				{{#if mapMoved}}
 	    		<button class="btn btn-mapzen" {{action "updatebbox"}}>Redo search in map area</button>
 	  		{{/if}}
-				
+			<br>
 			</div>
 		  {{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null pin=pin serves=null vehicle_type=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Show Stops</button>{{/link-to}}
 		  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null pin=pin serves=null vehicle_type=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}  

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -34,13 +34,15 @@
 								{{else if operated_by}}
 									<form>
 										<strong>Operated by:</strong> {{operated_by}}<br>
-
-									  <div class="form-group-header">Style routes by:</div>
-											<div class="form-group" {{action "setRouteStyle" "mode"}}>
-										  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>
-										  	{{else}}<input type="radio" id="radio-1" name="option-one">{{/if}}
-										    <label for="radio-1">Mode</label>
-										  </div>
+									  <row>
+									  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
+									  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+									  </row>
+										<div class="form-group" {{action "setRouteStyle" "mode"}}>
+									  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>
+									  	{{else}}<input type="radio" id="radio-1" name="option-one">{{/if}}
+									    <label for="radio-1">Mode</label>
+									  </div>
 									</form>
 									{{#each model.routes as |route|}}
 										{{#if (eq hoverRoute route.onestop_id)}}
@@ -49,7 +51,10 @@
 							  	{{/each}}
 								{{else}}
 									<form>
-									  <div class="form-group-header">Style routes by:</div>
+									  <row>
+									  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
+									  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+									  </row>
 									  <div class="form-group" {{action "setRouteStyle" "mode"}}>
 									  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>
 									  	{{else}}<input type="radio" id="radio-1" name="option-one">{{/if}}
@@ -254,8 +259,10 @@
 				{{else if operated_by}}
 					<form>
 						<strong>Operated by:</strong> {{operated_by}}<br>
-
-					  <div class="form-group-header">Style routes by:</div>
+						<row>
+					  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
+					  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+					  </row>
 					  <div class="form-group" {{action "setRouteStyle" "mode"}}>
 					  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>
 					  	{{else}}<input type="radio" id="radio-1" name="option-one">{{/if}}
@@ -282,8 +289,7 @@
 				<form>
 					<row>
 				  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
-				  	<!-- <div class="fa fa-question-circle style-routes-by col-md-2"></div> -->
-				  	<div tooltip="test test test test test test testtesttesttesttesttesttesttest testtest test test test v" class="col-md-2"><div class="fa fa-question-circle"></div></div>
+				  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
 				  </row>
 				  <div class="form-group" {{action "setRouteStyle" "mode"}}>
 				  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -283,7 +283,7 @@
 					<row>
 				  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
 				  	<!-- <div class="fa fa-question-circle style-routes-by col-md-2"></div> -->
-				  	<div tooltip><div class="fa fa-question-circle"></div></div>
+				  	<div tooltip="test test test test test test testtesttesttesttesttesttesttest testtest test test test v" class="col-md-2"><div class="fa fa-question-circle"></div></div>
 				  </row>
 				  <div class="form-group" {{action "setRouteStyle" "mode"}}>
 				  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -280,7 +280,11 @@
 		  	{{/each}}
 			{{else}}
 				<form>
-				  <div class="form-group-header">Style routes by:</div>
+					<row>
+				  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
+				  	<!-- <div class="fa fa-question-circle style-routes-by col-md-2"></div> -->
+				  	<div tooltip><div class="fa fa-question-circle"></div></div>
+				  </row>
 				  <div class="form-group" {{action "setRouteStyle" "mode"}}>
 				  	{{#if (eq style_routes_by "mode")}}<input type="radio" id="radio-1" name="option-one" checked>
 				  	{{else}}<input type="radio" id="radio-1" name="option-one">{{/if}}

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -29,7 +29,12 @@
 								    <label for="check-1">Show stops served by route</label>
 								  </div>
 								  
-								  {{#link-to 'route-stop-patterns' (query-params bbox=bbox traversed_by=onestop_id onestop_id=null operated_by=null serves=null served_by=onestop_id vehicle_type=null pin=pin isochrone_mode=null)}}Show route stop patterns{{/link-to}}<br>
+								  
+								  <row>
+								  	<div class="form-group-header sidebar-header col-md-10">{{#link-to 'route-stop-patterns' (query-params bbox=bbox traversed_by=onestop_id onestop_id=null operated_by=null serves=null served_by=onestop_id vehicle_type=null pin=pin isochrone_mode=null)}}Show route stop patterns{{/link-to}}</div>
+								  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+								  </row>
+								  <br>
 							  
 								{{else if operated_by}}
 									<form>
@@ -254,7 +259,12 @@
 				    <label for="check-1">Show stops served by route</label>
 				  </div>
 				  
-				  <div>{{#link-to 'route-stop-patterns' (query-params bbox=bbox traversed_by=onestop_id onestop_id=null operated_by=null serves=null served_by=onestop_id vehicle_type=null pin=pin isochrone_mode=null)}}Show route stop patterns{{/link-to}}</div><br>
+				  <!-- <row>
+				  	<div class="form-group-header sidebar-header col-md-10">{{#link-to 'route-stop-patterns' (query-params bbox=bbox traversed_by=onestop_id onestop_id=null operated_by=null serves=null served_by=onestop_id vehicle_type=null pin=pin isochrone_mode=null)}}Show route stop patterns{{/link-to}}</div>
+				  	<div tooltip="View route lines and display them by the route's transit mode or operator. Click a route on the map or in the list for its details." class="col-md-2"><div class="fa fa-question-circle"></div></div>
+				  </row>
+					<br> -->
+
 			  
 				{{else if operated_by}}
 					<form>

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -280,6 +280,9 @@
 		  	{{/each}}
 			{{else}}
 				<form>
+					{{#unless hoverRoute}}
+		  			<p class="caption">Hover over a route line for more information</p>
+			  	{{/unless}}
 					<row>
 				  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
 				  	<!-- <div class="fa fa-question-circle style-routes-by col-md-2"></div> -->
@@ -357,9 +360,9 @@
 						<p class="caption">Click the stop for more information</p>
 					</div>
 				{{/if}}
-				{{#unless hoverRoute}}
+				<!-- {{#unless hoverRoute}}
 		  			<p class="caption">Hover over a route line for more information</p>
-			  {{/unless}}
+			  {{/unless}} -->
 				{{#if mapMoved}}
 	    		<button class="btn btn-mapzen" {{action "updatebbox"}}>Redo search in map area</button>
 	  		{{/if}}

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -280,9 +280,6 @@
 		  	{{/each}}
 			{{else}}
 				<form>
-					{{#unless hoverRoute}}
-		  			<p class="caption">Hover over a route line for more information</p>
-			  	{{/unless}}
 					<row>
 				  	<div class="form-group-header sidebar-header col-md-10">Style routes by:</div>
 				  	<!-- <div class="fa fa-question-circle style-routes-by col-md-2"></div> -->
@@ -360,9 +357,9 @@
 						<p class="caption">Click the stop for more information</p>
 					</div>
 				{{/if}}
-				<!-- {{#unless hoverRoute}}
+				{{#unless hoverRoute}}
 		  			<p class="caption">Hover over a route line for more information</p>
-			  {{/unless}} -->
+			  {{/unless}}
 				{{#if mapMoved}}
 	    		<button class="btn btn-mapzen" {{action "updatebbox"}}>Redo search in map area</button>
 	  		{{/if}}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -352,7 +352,7 @@ input, button, select, textarea {
 	z-index: 40;
 	margin-top: 10px;
 	margin-left: 50px;
-	width: 250px;
+	width: 450px;
 	z-index: 2;
 	position: absolute;
 	background-size: 19px 19px;

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -83,18 +83,18 @@ caption{
 
 .fa-question-circle{
 	color: #c4c4c4;
-    float: left;
-    background-position: center center;
-    position: relative;
+	font-size: 18px;
 }
 
-
+.fa-question-circle:hover{
+	color: #898989;
+}
 
 [tooltip]:hover:before {
     position: absolute;
     content:' ';
-    top: 15px;
-    left: 10px;
+    top: 20px;
+    left:12px;
     width: 0;
     height: 0;
     opacity: 1;
@@ -102,11 +102,10 @@ caption{
 	  border-right: 10px solid transparent;
 	  border-bottom: 10px solid #bbb;
 }
-[tooltip]:hover:after{
-	/*content: "test";*/
-  content: attr(tooltip);
 
-  width: 250px;
+[tooltip]:hover:after{
+  content: attr(tooltip);
+  width: 200px;
   height: auto;
   position: absolute;
   text-align: left;
@@ -114,18 +113,12 @@ caption{
   font-size: 14px;
   line-height: 1.2em;
   padding: 10px 15px;
-  top: 25px;
-  left: -210px;
+  top: 30px;
+  left: -160px;
   background-color: #bbb;
-  z-index: 10000;
-  -webkit-box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);
+  z-index: 10;
+  /*-webkit-box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);*/
   box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);;
-}
-
-
-
-.fa-question-circle:hover{
-	color: #898989;
 }
 
 .sidebar-hr{

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -77,6 +77,55 @@ caption{
 	/*overflow-y: scroll;*/
 }
 
+.sidebar-header{
+	padding: 0;
+}
+
+.fa-question-circle{
+	color: #c4c4c4;
+    float: left;
+    background-position: center center;
+    position: relative;
+}
+
+
+
+[tooltip]:hover:before {
+    content: attr(tooltip);
+    position: absolute;
+    top: 30px;
+    left: 0;
+    width: 0;
+    height: 0;
+    opacity: 1;
+	  border-left: 10px solid transparent;
+	  border-right: 10px solid transparent;
+	  border-bottom: 10px solid #bbb;
+}
+[tooltip]:hover:after{
+	content: "test";
+  width: 200px;
+  height: auto;
+  position: absolute;
+  text-align: left;
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.2em;
+  padding: 10px 15px;
+  top: 40px;
+  left: -30px;
+  background-color: #bbb;
+  z-index: 10;
+  -webkit-box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);
+  box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);;
+}
+
+
+
+.fa-question-circle:hover{
+	color: #898989;
+}
+
 .sidebar-hr{
 	noshade: noshade;
 	align: center;

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -91,10 +91,10 @@ caption{
 
 
 [tooltip]:hover:before {
-    content: attr(tooltip);
     position: absolute;
-    top: 30px;
-    left: 0;
+    content:' ';
+    top: 15px;
+    left: 10px;
     width: 0;
     height: 0;
     opacity: 1;
@@ -103,8 +103,10 @@ caption{
 	  border-bottom: 10px solid #bbb;
 }
 [tooltip]:hover:after{
-	content: "test";
-  width: 200px;
+	/*content: "test";*/
+  content: attr(tooltip);
+
+  width: 250px;
   height: auto;
   position: absolute;
   text-align: left;
@@ -112,10 +114,10 @@ caption{
   font-size: 14px;
   line-height: 1.2em;
   padding: 10px 15px;
-  top: 40px;
-  left: -30px;
+  top: 25px;
+  left: -210px;
   background-color: #bbb;
-  z-index: 10;
+  z-index: 10000;
   -webkit-box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);
   box-shadow: 2px 2px 1px 0 rgba(50,50,50,.75);;
 }


### PR DESCRIPTION
This adds in tooltips for the routes template (to help explain the "style by" option and the link to route stop patterns).

Instead of adding a tooltip to the isochrone helper text, I just added a bit to the text that was there.

@rmglennon would you like to take a look before this gets merged?