### PR TITLE
move sidebar titles and captions to components

### DIFF
--- a/app/components/sidebar-title-mobility/component.js
+++ b/app/components/sidebar-title-mobility/component.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+});

--- a/app/components/sidebar-title-mobility/template.hbs
+++ b/app/components/sidebar-title-mobility/template.hbs
@@ -1,0 +1,6 @@
+<h4>Analyze access</h4>
+<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">
+    <!-- Use Mapzen Mobility services to see how public transit, driving, bicycling, and walking options shape our ability to get around.  -->
+    See how public transit, driving, bicycling, and walking options shape our ability to get around.
+    <!-- Analysis is powered by Mapzen Mobility services, using data from Transitland and OpenStreetMap. -->
+</caption>

--- a/app/components/sidebar-title-transitland/component.js
+++ b/app/components/sidebar-title-transitland/component.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+});

--- a/app/components/sidebar-title-transitland/template.hbs
+++ b/app/components/sidebar-title-transitland/template.hbs
@@ -1,0 +1,2 @@
+<h4>Visualize public transit networks</h4>
+<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Transitland highlights the connections that exist between transit datasets</caption>

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -9,16 +9,14 @@
         </div>
         <h2>Mobility Explorer</h2>
         {{text-box route="index"}}
-        <h4>Data</h4>
-          <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+        {{sidebar-title-transitland}}
             <div class="btn-group-vertical" role="group" >
               {{#link-to 'routes' (query-params bbox=bbox onestop_id=null operated_by=null pin=pin style_routes_by=null pin=pin serves=null)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
               {{#link-to 'stops' (query-params bbox=bbox onestop_id=null isochrone_mode=null pin=pin)}}<button class="btn btn-transparent-alt">Show Stops</button>{{/link-to}}
               {{#link-to 'operators' (query-params bbox=bbox onestop_id=null pin=pin)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}
             </div>
               <hr class="sidebar-hr">
-              <h4>Services</h4>
-              <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+              {{sidebar-title-mobility}}
               <div class="btn-group-vertical" role="group" >
                 {{#link-to 'isochrones' (query-params bbox=bbox onestop_id=null pin=pin)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
               </div>
@@ -66,27 +64,14 @@
     </div>
     <h2>Mobility Explorer</h2>
     {{text-box route="index"}}
-    <!-- <h4>Fixed route transit</h4> -->
-    <!-- <h4>Public transit network</h4> -->
-    <h4>Visualize public transit networks</h4>
-    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Transitland highlights the connections that exist between transit datasets</caption>
+    {{sidebar-title-transitland}}
     <div class="btn-group-vertical" role="group" >
-
       {{#link-to 'routes' (query-params bbox=bbox onestop_id=null operated_by=null pin=pin style_routes_by=null pin=pin serves=null)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
-
       {{#link-to 'stops' (query-params bbox=bbox onestop_id=null isochrone_mode=null pin=pin)}}<button class="btn btn-transparent-alt">Show Stops</button>{{/link-to}}
       {{#link-to 'operators' (query-params bbox=bbox pin=pin onestop_id=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}
     </div>
     <hr class="sidebar-hr">
-    <!-- <h4>Access analysis</h4>
-    <h4>Accessibility</h4> -->
-    <h4>Analyze access</h4>
-
-    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">
-        <!-- Use Mapzen Mobility services to see how public transit, driving, bicycling, and walking options shape our ability to get around.  -->
-        See how public transit, driving, bicycling, and walking options shape our ability to get around.
-        <!-- Analysis is powered by Mapzen Mobility services, using data from Transitland and OpenStreetMap. -->
-    </caption>
+      {{sidebar-title-mobility}}
       <div class="btn-group-vertical" role="group" >
       {{#link-to 'isochrones' (query-params bbox=bbox pin=pin onestop_id=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
     </div>

--- a/app/operators/template.hbs
+++ b/app/operators/template.hbs
@@ -9,8 +9,7 @@
         </div>
         {{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
         {{text-box route="index"}}
-        <h4>Data</h4>
-          <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+        {{sidebar-title-transitland}}
             <div class="btn-group-vertical" role="group" >
               {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
               {{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Show Stops</button>{{/link-to}}
@@ -49,8 +48,7 @@
               </div>
             </div>
             <hr class="sidebar-hr">
-            <h4>Services</h4>
-            <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+            {{sidebar-title-mobility}}
             <div class="btn-group-vertical" role="group" >
               {{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null isochrone_mode=null pin=pin)}}<button class="btn btn-transparent-alt">Show Isochrones</button>{{/link-to}}
             </div>
@@ -100,8 +98,7 @@
     </div>
     {{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null pin=pin operated_by=null serves=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
     {{text-box route="index"}}
-    <h4>Data</h4>
-    <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+    {{sidebar-title-transitland}}
     <div class="btn-group-vertical" role="group" >
     {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
     {{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Show Stops</button>{{/link-to}}
@@ -140,8 +137,7 @@
       </div>
       </div>
         <hr class="sidebar-hr">
-        <h4>Services</h4>
-        <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+        {{sidebar-title-mobility}}
         <div class="btn-group-vertical" role="group" >
         {{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null isochrone_mode=null pin=pin)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
         {{url-builder entity="operators" server="Transitland" query="results" queryParams=queryParams bbox=bbox onestop_id=onestop_id}}

--- a/app/route-stop-patterns/template.hbs
+++ b/app/route-stop-patterns/template.hbs
@@ -9,8 +9,7 @@
         </div>
 				{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
         {{text-box route="index"}}
-				 <h4>Data</h4>
-          <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+				{{sidebar-title-transitland}}
             <div class="btn-group-vertical" role="group" >
 						  {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null style_routes_by=null)}}<button class="btn btn-mapzen-alt">Show Routes</button>{{/link-to}}
 						  
@@ -74,8 +73,7 @@
 						  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}  
 					 	</div>
             <hr class="sidebar-hr">
-            <h4>Services</h4>
-            <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+            {{sidebar-title-mobility}}
             <div class="btn-group-vertical" role="group" >
               {{#link-to 'isochrones' (query-params bbox=bbox onestop_id=null pin=pin)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
             </div>
@@ -129,8 +127,7 @@
     </div>
 		{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
 		{{text-box route="index"}}
-		<h4>Data</h4>
-		<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+		{{sidebar-title-transitland}}
 		<div class="btn-group-vertical" role="group" >
 		  {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null style_routes_by=null)}}<button class="btn btn-mapzen-alt">Show Routes</button>{{/link-to}}
 		  
@@ -200,8 +197,7 @@
 			</div>
 		</div>
 		<hr class="sidebar-hr">
-		<h4>Services</h4>
-		<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+		{{sidebar-title-mobility}}
 		<div class="btn-group-vertical" role="group" >
 		  {{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Show Stops</button>{{/link-to}}
 		  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null vehicle_type=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}  

--- a/app/routes/template.hbs
+++ b/app/routes/template.hbs
@@ -9,8 +9,7 @@
         </div>
 				{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null pin=pin serves=null vehicle_type=null pin=pin)}}<h2>Mobility Explorer</h2>{{/link-to}}
         {{text-box route="index"}}
-				<h4>Data</h4>
-          <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+        {{sidebar-title-transitland}}
             <div class="btn-group-vertical" role="group" >
 						  {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null pin=pin served_by=null operated_by=null serves=null vehicle_type=null style_routes_by=null pin=pin)}}<button class="btn btn-mapzen-alt">Show Routes</button>{{/link-to}}
 						  
@@ -182,8 +181,7 @@
 						  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin vehicle_type=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}  
 			  		</div>
             <hr class="sidebar-hr">
-            <h4>Services</h4>
-            <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+            {{sidebar-title-mobility}}
             <div class="btn-group-vertical" role="group" >
 			  			{{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin vehicle_type=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}} 
 			  		</div> 
@@ -287,8 +285,7 @@
     </div>
 		{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null pin=pin serves=null vehicle_type=null)}}<h2>Mobility Explorer</h2>{{/link-to}}
 		{{text-box route="index"}}
-		<h4>Data</h4>
-		<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+    {{sidebar-title-transitland}}
 		<div class="btn-group-vertical" role="group" >
 
 		  {{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null pin=pin serves=null vehicle_type=null style_routes_by=null)}}<button class="btn btn-mapzen-alt">Show Routes</button>{{/link-to}}
@@ -477,8 +474,7 @@
 		  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null pin=pin serves=null vehicle_type=null)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}  
 	  </div>
 		<hr class="sidebar-hr">
-		<h4>Services</h4>
-		<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+		{{sidebar-title-mobility}}
 		<div class="btn-group-vertical" role="group" >
 	  	{{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null isochrone_mode=null operated_by=null pin=pin serves=null vehicle_type=null isochrone_mode=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}  
 	 	 {{url-builder entity="routes" server="Transitland" query="results" queryParams=queryParams bbox=bbox onestop_id=onestop_id serves=serves operated_by=operated_by vehicle_type=vehicle_type}}

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -9,8 +9,7 @@
         </div>
 				{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin)}}<h2>Mobility Explorer</h2>{{/link-to}}
 				{{text-box route="index"}}
-        	<h4>Data</h4>
-         	 <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+        	{{sidebar-title-transitland}}
            <div class="btn-group-vertical" role="group" >
 						{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null pin=pin)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
 						{{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=null pin=pin)}}<button class="btn btn-mapzen-alt">Show Stops</button>{{/link-to}}
@@ -88,8 +87,7 @@
 							</div>
 					  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}
 				   	<hr class="sidebar-hr">
-            <h4>Services</h4>
-            <caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+           {{sidebar-title-mobility}}
             <div class="btn-group-vertical" role="group" >
 			  			{{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null pin=pin isochrone_mode=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
 			  		</div>
@@ -168,8 +166,7 @@
 	    </div>
 		{{#link-to 'index' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin)}}<h2>Mobility Explorer</h2>{{/link-to}}
 		{{text-box route="index"}}
-		<h4>Data</h4>
-		<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Open transit data from Transitland</caption>
+		{{sidebar-title-transitland}}
 		<div class="btn-group-vertical" role="group" >
 			{{#link-to 'routes' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null pin=pin)}}<button class="btn btn-transparent-alt">Show Routes</button>{{/link-to}}
 			{{#link-to 'stops' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null isochrone_mode=null pin=pin)}}<button class="btn btn-mapzen-alt">Show Stops</button>{{/link-to}}
@@ -253,8 +250,7 @@
 		  {{#link-to 'operators' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null pin=pin)}}<button class="btn btn-transparent-alt">Show Operators</button>{{/link-to}}
 		</div>
 		<hr class="sidebar-hr">
-		<h4>Services</h4>
-		<caption class="sidebar-caption col-xl-12 col-lg-12 col-md-12 col-sm-12">Travel planning services from Mapzen</caption>
+		{{sidebar-title-mobility}}
 		<div class="btn-group-vertical" role="group" >
   		{{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null pin=pin isochrone_mode=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
   	</div>

--- a/tests/integration/components/sidebar-caption-mobility/component-test.js
+++ b/tests/integration/components/sidebar-caption-mobility/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('sidebar-caption-mobility', 'Integration | Component | sidebar caption mobility', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{sidebar-caption-mobility}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#sidebar-caption-mobility}}
+      template block text
+    {{/sidebar-caption-mobility}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/sidebar-title-mobility/component-test.js
+++ b/tests/integration/components/sidebar-title-mobility/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('sidebar-title-mobility', 'Integration | Component | sidebar title mobility', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{sidebar-title-mobility}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#sidebar-title-mobility}}
+      template block text
+    {{/sidebar-title-mobility}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/sidebar-title-transitland/component-test.js
+++ b/tests/integration/components/sidebar-title-transitland/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('sidebar-title-transitland', 'Integration | Component | sidebar title transitland', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{sidebar-title-transitland}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#sidebar-title-transitland}}
+      template block text
+    {{/sidebar-title-transitland}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Sidebar titles and their respective captions are now in components, so they can be edited in one location. 

The edits can be made in the template files of the components, found here:

- app/components/sidebar-title-mobility

- app/components/sidebar-title-transitland

cc @drewda @rmglennon 

closes #236 