### PR TITLE
Analytics#174

### DIFF
--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+});

--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -8,7 +8,7 @@ export default Ember.Mixin.create({
 
   pageviewToGA: Ember.on('didTransition', function(page, title) {
     var page = page ? page : this.get('url');
-    // page = Ember.getWithDefault(ENV, 'baseURL', '') + page;
+    page = Ember.getWithDefault(ENV, 'baseURL', '') + page;
     var title = title ? title : this.get('url');
 
     if (Ember.get(ENV, 'googleAnalytics.webPropertyId') != null) {

--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -1,4 +1,32 @@
 import Ember from 'ember';
+import ENV from '../config/environment';
 
 export default Ember.Mixin.create({
+  beforePageviewToGA: function (ga) {
+
+  },
+
+  pageviewToGA: Ember.on('didTransition', function(page, title) {
+    var page = page ? page : this.get('url');
+    // page = Ember.getWithDefault(ENV, 'baseURL', '') + page;
+    var title = title ? title : this.get('url');
+
+    if (Ember.get(ENV, 'googleAnalytics.webPropertyId') != null) {
+      var trackerType = Ember.getWithDefault(ENV, 'googleAnalytics.tracker', 'analytics.js');
+
+      if (trackerType === 'analytics.js') {
+        var globalVariable = Ember.getWithDefault(ENV, 'googleAnalytics.globalVariable', 'ga');
+
+        this.beforePageviewToGA(window[globalVariable]);
+
+        window[globalVariable]('send', 'pageview', {
+          page: page,
+          title: title
+        });
+      } else if (trackerType === 'ga.js') {
+        window._gaq.push(['_trackPageview']);
+      }
+    }
+  })
+
 });

--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import config from './config/environment';
+import googlePageview from './mixins/google-pageview';
 
-const Router = Ember.Router.extend({
+
+const Router = Ember.Router.extend(googlePageview, {
   location: config.locationType
 });
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -54,9 +54,10 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    // ENV.googleAnalytics = {
-    //   webPropertyId: 'UA-47035811-4'
-    // };
+    ENV.googleAnalytics = {
+      webPropertyId: 'UA-47035811-1'
+    
+    };
     ENV.baseURL = '/mobility/explorer/';
 
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,6 +36,9 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    // ENV.googleAnalytics = {
+    //   webPropertyId: 'UA-47035811-4'
+    // };
     ENV.transitlandDatastoreHost = 'https://dev.transit.land';
 
   }
@@ -47,11 +50,13 @@ module.exports = function(environment) {
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
-
     ENV.APP.rootElement = '#ember-testing';
   }
 
   if (environment === 'production') {
+    // ENV.googleAnalytics = {
+    //   webPropertyId: 'UA-47035811-4'
+    // };
     ENV.baseURL = '/mobility/explorer/';
 
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-bootstrap-datetimepicker": "0.3.1",
     "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-google-analytics": "^1.5.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",

--- a/tests/unit/mixins/google-pageview-test.js
+++ b/tests/unit/mixins/google-pageview-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import GooglePageviewMixin from 'mobility-playground/mixins/google-pageview';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | google pageview');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let GooglePageviewObject = Ember.Object.extend(GooglePageviewMixin);
+  let subject = GooglePageviewObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
Adds Google Analytics tracking using ember-cli-google-analytics.

@drewda do I need to use/modify this line: https://github.com/mapzen/mobility-explorer/compare/analytics%23174?expand=1#diff-9537a9e5df770e02c080cbcf3f9f6b74R11

closes #174 