### PR TITLE
Cleanup jshint errors across application

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,5 +28,5 @@
   "white": false,
   "eqnull": true,
   "esnext": true,
-  "unused": true
+  "unused": "vars"
 }

--- a/app/components/isochrone-legend/component.js
+++ b/app/components/isochrone-legend/component.js
@@ -3,13 +3,13 @@ import Ember from 'ember';
 export default Ember.Component.extend({
 	mode: Ember.computed('isochrone_mode', function(){
 		if (this.get('isochrone_mode') === "pedestrian"){
-			return "walk"
+			return "walk";
 		} else if (this.get('isochrone_mode') === "bicycle"){
-			return "ride"
+			return "ride";
 		} else if (this.get('isochrone_mode') === 'multimodal'){
-			return "trip"
+			return "trip";
 		} else if (this.get('isochrone_mode') === 'auto'){
-			return "drive"
+			return "drive";
 		}
 	})
 });

--- a/app/components/map-explorer/component.js
+++ b/app/components/map-explorer/component.js
@@ -1,3 +1,5 @@
+/* global L */
+
 import Ember from 'ember';
 
 export default Ember.Component.extend({

--- a/app/components/side-nav/component.js
+++ b/app/components/side-nav/component.js
@@ -15,17 +15,17 @@ export default Ember.Component.extend({
   	}
   },
   activeOperatorsRoute: function(){
-  	if (activeRoute === 'operators'){
+  	if (this.activeRoute === 'operators'){
   		return true;
   	}
   },
   activeRoutesRoute: function(){
-  	if(activeRoute === 'routes'){
+  	if(this.activeRoute === 'routes'){
   		return true;
   	}
   },
   activeStopsRoute: function(){
-  	if(activeRoute === 'stops'){
+  	if(this.activeRoute === 'stops'){
   		return true;
   	}
   }

--- a/app/components/text-box/component.js
+++ b/app/components/text-box/component.js
@@ -14,13 +14,13 @@ export default Ember.Component.extend({
 			'isochrones' : ''
 	},
 	text: Ember.computed('route', function(){
-		return this.get('textOptions')[this.get('route')]
+		return this.get('textOptions')[this.get('route')];
 	}),
 	actions:{
 		close: function(){
 			this.sendAction();
 		}
 	}
-	
-	
+
+
 });

--- a/app/components/url-builder/component.js
+++ b/app/components/url-builder/component.js
@@ -5,11 +5,11 @@ export default Ember.Component.extend({
 		if (this.entity === 'isochrones'){
 			return this.url;
 		} else {
-			var url = "https://transit.land/api/v1/" + this.entity + "?"
+			var url = "https://transit.land/api/v1/" + this.entity + "?";
 			var arrayOfQueryParams = ['style_routes_by', 'isochrone_mode', 'bus_only'];
 			for (var i = 0; i < this.get('queryParams').length; i++){
 				if (arrayOfQueryParams.indexOf(this.get('queryParams')[i]) === -1 && this.get(this.get('queryParams')[i]) !== null){
-					arrayOfQueryParams.push(this.get('queryParams')[i])
+					arrayOfQueryParams.push(this.get('queryParams')[i]);
 					if (i === 0){
 						url = url + this.get('queryParams')[i] + "=" + this.get(this.get('queryParams')[i]);
 					} else {

--- a/app/data/transitland/route-stop-pattern/model.js
+++ b/app/data/transitland/route-stop-pattern/model.js
@@ -64,7 +64,7 @@ var Route_stop_pattern = DS.Model.extend({
 					},
 				},
 			]
-		}
+		};
 	}).property('is_selected'),
 });
 

--- a/app/data/transitland/route/model.js
+++ b/app/data/transitland/route/model.js
@@ -55,7 +55,7 @@ var Route = DS.Model.extend({
 					},
 				},
 			]
-		}
+		};
 	}).property('geometry'),
 	operator_focus_as_geojson_with_outline: (function(){
 		return {
@@ -82,7 +82,7 @@ var Route = DS.Model.extend({
 					},
 				},
 			]
-		}
+		};
 	}).property('geometry'),
 
 	mode_as_geojson_with_outline: (function(){
@@ -95,11 +95,11 @@ var Route = DS.Model.extend({
 			c : 12,
 			d : 13,
 			e : 14,
-			f : 15, 
-		}
+			f : 15,
+		};
 
 		for (var i = 0; i < 6; i++){
-			let hexDigit = hexValue[i]
+			let hexDigit = hexValue[i];
 			if (hexDigit >= 0){
 				hexValue[i] = Number.parseInt(hexDigit);
 			} else {
@@ -110,7 +110,7 @@ var Route = DS.Model.extend({
 		let red = (hexValue[0] * 16) + hexValue[1];
 		let green = (hexValue[2] * 16) + hexValue[3];
 		let blue = (hexValue[4] * 16) + hexValue[5];
-		
+
 		// from turn-by-turn demo:
 		var lum = 0.299 * red + 0.587 * green + 0.114 * blue,
     is_light = (lum > 0xbb);
@@ -141,7 +141,7 @@ var Route = DS.Model.extend({
 					},
 				},
 			]
-		}
+		};
 	}).property('geometry'),
 	operator_as_geojson_with_outline: (function(){
 		let lineColor = this.get('operator_color');
@@ -153,27 +153,17 @@ var Route = DS.Model.extend({
 			c : 12,
 			d : 13,
 			e : 14,
-			f : 15, 
-		}
+			f : 15,
+		};
 
 		for (var i = 0; i < 6; i++){
-			let hexDigit = hexValue[i]
+			let hexDigit = hexValue[i];
 			if (hexDigit >= 0){
 				hexValue[i] = Number.parseInt(hexDigit);
 			} else {
 				hexValue[i] = hexLetters[hexDigit];
 			}
 		}
-
-		let red = (hexValue[0] * 16) + hexValue[1];
-		let green = (hexValue[2] * 16) + hexValue[3];
-		let blue = (hexValue[4] * 16) + hexValue[5];
-		
-		// from turn-by-turn demo:
-		var lum = 0.299 * red + 0.587 * green + 0.114 * blue,
-    is_light = (lum > 0xbb);
-
-    let borderColor = (is_light ? '#666666' : '#f8f8f8');
 
 		return {
 			type: "FeatureCollection",
@@ -199,7 +189,7 @@ var Route = DS.Model.extend({
 					},
 				},
 			]
-		}
+		};
 	}).property('geometry'),
 	rsp_route_as_geojson_with_outline: (function(){
 		return {
@@ -226,7 +216,7 @@ var Route = DS.Model.extend({
 					},
 				},
 			]
-		}
+		};
 	}).property('geometry'),
 	operator_color: (function(){
 		var str = this.get('operated_by_onestop_id');
@@ -241,7 +231,7 @@ var Route = DS.Model.extend({
 		colorCode = "#" + colorCode;
 		return colorCode;
 	}).property('operated_by_onestop_id'),
-	
+
 	operated_by_route_default_color: (function(){
 		if (this.get('color') !== null && this.get('color') !== "ffffff"){
 			return "#" + this.get('color');

--- a/app/data/transitland/serializer.js
+++ b/app/data/transitland/serializer.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -1,3 +1,5 @@
+/* global L */
+
 import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 import setTextboxClosed from 'mobility-playground/mixins/set-textbox-closed';
@@ -24,7 +26,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
   }),
   currentlyLoading: Ember.inject.service(),
 	icon: L.icon({
-		iconUrl: 'assets/images/marker1.png',		
+		iconUrl: 'assets/images/marker1.png',
 		iconSize: (20, 20),
     iconAnchor: [10, 24],
 	}),
@@ -45,7 +47,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
 		},
   	searchRepo(term) {
       if (Ember.isBlank(term)) { return []; }
-      const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`;      
+      const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`;
       return Ember.$.ajax({ url }).then(json => json.features);
     },
   	setPlace: function(selected){
@@ -55,7 +57,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
       var coordinates = [];
       coordinates.push(lat);
       coordinates.push(lng);
-      
+
       this.set('place', selected);
       this.set('pin', coordinates);
       this.set('center', coordinates);

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 import setLoading from 'mobility-playground/mixins/set-loading';
 
 export default Ember.Route.extend(setLoading, {
@@ -25,7 +24,7 @@ export default Ember.Route.extend(setLoading, {
 			for (var i = 0; i < coordinateArray.length; i++){
 				tempArray.push(parseFloat(coordinateArray[i]));
 			}
-		
+
 			var arrayOne = [];
 			var arrayTwo = [];
 			arrayOne.push(tempArray[1]);
@@ -38,11 +37,11 @@ export default Ember.Route.extend(setLoading, {
 		}
     controller.set('leafletBbox', controller.get('bbox'));
     this._super(controller, model);
-		
+
 	},
 	actions: {
 	}
 });
 
 
-  
+

--- a/app/isochrones/controller.js
+++ b/app/isochrones/controller.js
@@ -1,3 +1,5 @@
+/* global moment, L */
+
 import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 import setTextboxClosed from 'mobility-playground/mixins/set-textbox-closed';
@@ -23,7 +25,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
   place: null,
   currentlyLoading: Ember.inject.service(),
 	icon: L.icon({
-		iconUrl: 'assets/images/marker1.png',		
+		iconUrl: 'assets/images/marker1.png',
 		iconSize: (20, 20),
     iconAnchor: [10, 24],
 	}),
@@ -49,7 +51,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
     },
   	searchRepo(term) {
       if (Ember.isBlank(term)) { return []; }
-      const url = `https://search.mapzen.com/v1/autocomplete?api_key=search-ab7NChg&text=${term}`;      
+      const url = `https://search.mapzen.com/v1/autocomplete?api_key=search-ab7NChg&text=${term}`;
       return Ember.$.ajax({ url }).then(json => json.features);
     },
   	setPlace: function(selected){
@@ -71,9 +73,6 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
     closePopup: function(e){
       // debugger;
       e.target.closePopup();
-    },
-    removePin: function(){
-      this.set('pin', null);
     },
     dropPin: function(e){
       var lat = e.latlng.lat;
@@ -129,17 +128,17 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
         'Oct' : '10',
         'Nov' : '11',
         'Dec' : '12'
-      }
-      var newDepartureTime = year + "-" + month[monthString] + "-" + day + "T" + hour + ":" + minute
+      };
+      var newDepartureTime = year + "-" + month[monthString] + "-" + day + "T" + hour + ":" + minute;
 
-      // This is the local date and time at the location.  
+      // This is the local date and time at the location.
       // value:
-      // the date and time is specified in ISO 8601 format (YYYY-MM-DDThh:mm) in 
+      // the date and time is specified in ISO 8601 format (YYYY-MM-DDThh:mm) in
       // the local time zone of departure or arrival. For example "2016-07-03T08:06"
-      // ISO 8601 uses the 24-hour clock system. 
-      // A single point in time can be represented by concatenating a complete date expression, 
+      // ISO 8601 uses the 24-hour clock system.
+      // A single point in time can be represented by concatenating a complete date expression,
       // the letter T as a delimiter, and a valid time expression. For example, "2007-04-05T14:30".
-      
+
       this.set('departure_time', newDepartureTime);
 		},
     resetDepartureTime: function(){

--- a/app/isochrones/route.js
+++ b/app/isochrones/route.js
@@ -1,8 +1,5 @@
 import Ember from 'ember';
-import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 import setLoading from 'mobility-playground/mixins/set-loading';
-import polygon from 'npm:turf-polygon';
-import difference from 'npm:turf-difference';
 
 
 export default Ember.Route.extend(setLoading, {
@@ -32,7 +29,7 @@ export default Ember.Route.extend(setLoading, {
 			for (var i = 0; i < coordinateArray.length; i++){
 				tempArray.push(parseFloat(coordinateArray[i]));
 			}
-		
+
 			var arrayOne = [];
 			var arrayTwo = [];
 			arrayOne.push(tempArray[1]);
@@ -46,7 +43,7 @@ export default Ember.Route.extend(setLoading, {
 		}
 		controller.set('leafletBbox', controller.get('bbox'));
     this._super(controller, model);
-		
+
 	},
 	model: function(params){
     this.store.unloadAll('data/transitland/operator');
@@ -55,21 +52,20 @@ export default Ember.Route.extend(setLoading, {
     this.store.unloadAll('data/transitland/route_stop_pattern');
 
     if (params.isochrone_mode){
-	    var self = this;
-	    var pinLocation = params.pin;			
+	    var pinLocation = params.pin;
 
 	    if (typeof(pinLocation)==="string"){
 	      var pinArray = pinLocation.split(',');
 	      pinLocation = pinArray;
-	    } 
+	    }
 
 	    var mode = params.isochrone_mode;
 	    var url = 'https://matrix.mapzen.com/isochrone?api_key=mapzen-jLrDBSP&json=';
 	    var linkUrl = 'https://matrix.mapzen.com/isochrone?json=';
 	    var json = {
 	      locations: [{"lat":pinLocation[0], "lon":pinLocation[1]}],
-	      costing: mode,	      
-	      denoise: .3,
+	      costing: mode,
+	      denoise: 0.3,
 	      polygons: true,
         generalize: 50,
 	      costing_options: {"pedestrian":{"use_ferry":0}},
@@ -86,8 +82,8 @@ export default Ember.Route.extend(setLoading, {
 	    	json.date_time = {"type": 1, "value": params.departure_time};
 	    }
 
-	    url += escape(JSON.stringify(json));
-	    linkUrl += escape(JSON.stringify(json));
+	    url = encodeURI(url + JSON.stringify(json));
+	    linkUrl = encodeURI(linkUrl + JSON.stringify(json));
 	    return Ember.RSVP.hash({
 	      url: url,
 	      linkUrl: linkUrl,
@@ -105,12 +101,12 @@ export default Ember.Route.extend(setLoading, {
 	        return response;
 	      })
 	    });
-	  } 
-    
+	  }
+
   },
 	actions: {
 	}
 });
 
 
-  
+

--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -7,9 +7,9 @@ export default Ember.Mixin.create({
   },
 
   pageviewToGA: Ember.on('didTransition', function(page, title) {
-    var page = page ? page : this.get('url');
+    page = page ? page : this.get('url');
     page = Ember.getWithDefault(ENV, 'baseURL', '') + page;
-    var title = title ? title : this.get('url');
+    title = title ? title : this.get('url');
 
     if (Ember.get(ENV, 'googleAnalytics.webPropertyId') != null) {
       var trackerType = Ember.getWithDefault(ENV, 'googleAnalytics.tracker', 'analytics.js');

--- a/app/operators/controller.js
+++ b/app/operators/controller.js
@@ -1,3 +1,5 @@
+/* global L */
+
 import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 import setTextboxClosed from 'mobility-playground/mixins/set-textbox-closed';
@@ -27,32 +29,32 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
 		if (total > 1){
 			return  total + " operators";
 		} else if (total === 1) {
-			return total + " operator"
+			return total + " operator";
 		}
 	}),
 	onlyOperator: Ember.computed('onestop_id', function(){
 		var data = this.get('operators');
 		var onlyOperator = data.get('firstObject');
 		if (this.get('onestop_id') === null){
-			return null
+			return null;
 		} else {
 			return onlyOperator;
 		}
 	}),
 	icon: L.icon({
-		iconUrl: 'assets/images/marker.png',		
+		iconUrl: 'assets/images/marker.png',
 		iconSize: (20, 20),
     iconAnchor: [10, 24],
 	}),
 	operators: Ember.computed('model', function(){
 		if (this.get('model') === null){
-			return
+			return;
 		} else {
 			var data = this.get('model');
 			var operators = [];
 			operators = operators.concat(data.map(function(operator){return operator;}));
 			return operators;
-		}	
+		}
 	}),
 	mapMoved: false,
 	mousedOver: false,
@@ -102,7 +104,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
 		},
 		searchRepo(term) {
       if (Ember.isBlank(term)) { return []; }
-      const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`; 
+      const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`;
       return Ember.$.ajax({ url }).then(json => json.features);
     },
    	setPlace: function(selected){
@@ -112,7 +114,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
       var coordinates = [];
       coordinates.push(lat);
       coordinates.push(lng);
-      
+
   		this.set('place', selected);
       this.set('pin', coordinates);
       this.transitionToRoute('index', {queryParams: {pin: this.get('pin'), bbox: null}});
@@ -131,5 +133,5 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
       coordinates.push(lng);
       this.set('pin', coordinates);
     }
-	}	
+	}
 });

--- a/app/route-stop-patterns/controller.js
+++ b/app/route-stop-patterns/controller.js
@@ -32,7 +32,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 			for (var i = 0; i < coordinateArray.length; i++){
 				tempArray.push(parseFloat(coordinateArray[i]));
 			}
-		
+
 			var arrayOne = [];
 			var arrayTwo = [];
 			arrayOne.push(tempArray[1]);
@@ -71,7 +71,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 			this.set('mousedOver', true);
 		},
 		onEachFeature(feature, layer){
-			layer.setStyle(feature.properties);	
+			layer.setStyle(feature.properties);
 		},
 		setOnestopId(route) {
 			var onestopId = route.id;
@@ -87,7 +87,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
         var coordinates = [];
         coordinates.push(lat);
         coordinates.push(lng);
-        this.set('mapCenter', coordinates); 
+        this.set('mapCenter', coordinates);
         this.set('pin', coordinates);
       }
 			this.set('place', selected);
@@ -106,12 +106,12 @@ export default Ember.Controller.extend(setTextboxClosed, {
       var coordinates = [];
       coordinates.push(lat);
       coordinates.push(lng);
-      this.set('mapCenter', coordinates); 
+      this.set('mapCenter', coordinates);
       this.set('pin', coordinates);
     },
 		searchRepo(term) {
 			if (Ember.isBlank(term)) { return []; }
-			const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`; 
+			const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`;
 			return Ember.$.ajax({ url }).then(json => json.features);
 		},
 		displayStops: function(){
@@ -133,12 +133,13 @@ export default Ember.Controller.extend(setTextboxClosed, {
   		this.transitionToRoute('stops', {queryParams: {bbox: this.get('bbox'), onestop_id: this.get('onestop_id')}});
 		},
 		setRsp: function(rsp){
+      var stops, stopsLength, stopId, i;
 			if (this.get('selectedRsp')!== null){
-				var stops = this.get('selectedRsp').get('stop_pattern')
-				var stopsLength = stops.length
-				for (var i = 0; i < stopsLength; i++){ 
-					var stopId = stops[i]; 
-					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', null)
+				stops = this.get('selectedRsp').get('stop_pattern');
+				stopsLength = stops.length;
+				for (i = 0; i < stopsLength; i++){
+					stopId = stops[i];
+					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', null);
 				}
 			}
 			if (this.get('selectedRsp')!== null && this.get('selectedRsp').get('id') === rsp.get('id')){
@@ -146,37 +147,37 @@ export default Ember.Controller.extend(setTextboxClosed, {
 				rsp.set('is_selected', false);
 				rsp.set('default_opacity', 0);
 			} else if (this.get('selectedRsp')!== null){
-				var stops = this.get('selectedRsp').get('stop_pattern')
-				var stopsLength = stops.length
-				for (var i = 0; i < stopsLength; i++){ 
-					var stopId = stops[i]; 
-					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', null)
+				stops = this.get('selectedRsp').get('stop_pattern');
+				stopsLength = stops.length;
+				for (i = 0; i < stopsLength; i++){
+					stopId = stops[i];
+					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', null);
 				}
 				this.get('selectedRsp').set('default_opacity', 0);
-				
+
 				rsp.set('default_opacity', 1);
 				this.get('selectedRsp').set('is_selected', false);
 				rsp.set('is_selected', true);
 				this.set('selectedRsp', rsp);
-				stops = this.selectedRsp.get('stop_pattern')
-				stopsLength = stops.length
-				for (var i = 0; i < stopsLength; i++){ 
-					var stopId = stops[i]; 
-					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', i+1)
+				stops = this.selectedRsp.get('stop_pattern');
+				stopsLength = stops.length;
+				for (i = 0; i < stopsLength; i++){
+					stopId = stops[i];
+					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', i+1);
 				}
 			}
 			else {
 				this.set('selectedRsp', rsp);
 				rsp.set('is_selected', true);
 				rsp.set('default_opacity', 1);
-				var stops = this.selectedRsp.get('stop_pattern')
-				var stopsLength = stops.length
-				for (var i = 0; i < stopsLength; i++){ 
-					var stopId = stops[i]; 
-					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', i+1)
+				stops = this.selectedRsp.get('stop_pattern');
+				stopsLength = stops.length;
+				for (i = 0; i < stopsLength; i++){
+					stopId = stops[i];
+					this.store.peekRecord('data/transitland/stop',stopId).set('rsp_stop_pattern_number', i+1);
 				}
 			}
 		}
 	}
-	
+
 });

--- a/app/routes/controller.js
+++ b/app/routes/controller.js
@@ -1,3 +1,5 @@
+/* global L */
+
 import Ember from 'ember';
 import setTextboxClosed from 'mobility-playground/mixins/set-textbox-closed';
 
@@ -30,7 +32,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 		if (total > 1){
 			return  total + " routes";
 		} else if (total === 1) {
-			return total + " route"
+			return total + " route";
 		}
 	}),
 	placeholderMessageOperators: Ember.computed('leafletBbox', function(){
@@ -38,7 +40,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 		if (total > 1){
 			return  total + " operators";
 		} else if (total === 1) {
-			return total + " operator"
+			return total + " operator";
 		}
 	}),
 	placeholderMessageModes: Ember.computed('leafletBbox', function(){
@@ -46,7 +48,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 		if (total > 1){
 			return  total + " modes";
 		} else if (total === 1) {
-			return total + " mode"
+			return total + " mode";
 		}
 	}),
 	routeOperators: Ember.computed('leafletBbox', function(){
@@ -88,7 +90,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 			if (modeName in modeColors){
 				modeColor = modeColors[modeName];
 			} else {
-				modeColor = "grey"
+				modeColor = "grey";
 			}
 			if (checkList.indexOf(modeName) === -1){
 				checkList.push(modeName);
@@ -119,7 +121,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 		var data = this.get('routes');
 		var onlyRoute = data.get('firstObject');
 		if (this.get('onestop_id') === null){
-			return null
+			return null;
 		} else {
 			return onlyRoute;
 		}
@@ -143,7 +145,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 			for (var i = 0; i < coordinateArray.length; i++){
 				tempArray.push(parseFloat(coordinateArray[i]));
 			}
-		
+
 			var arrayOne = [];
 			var arrayTwo = [];
 			arrayOne.push(tempArray[1]);
@@ -156,7 +158,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 		}
 	}),
 	icon: L.icon({
-		iconUrl: 'assets/images/marker1.png',		
+		iconUrl: 'assets/images/marker1.png',
 		iconSize: (20, 20),
     iconAnchor: [10, 24]
 	}),
@@ -195,7 +197,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 			}
 		},
 		mouseOver(){
-			this.set('mousedOver', true);	
+			this.set('mousedOver', true);
 		},
 		setRouteStyle(style){
 			if (this.get('style_routes_by') === style){
@@ -232,8 +234,8 @@ export default Ember.Controller.extend(setTextboxClosed, {
 				"opacity": 1,
 				"weight": 5,
 			});
-			this.set('hoverRoute', (e.target.getLayers()[0].feature.onestop_id));	
-		
+			this.set('hoverRoute', (e.target.getLayers()[0].feature.onestop_id));
+
 
 		},
 		setOnestopId: function(route) {
@@ -250,7 +252,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
 			layer.originalStyle = feature.properties;
 
 			if (this.get('onestop_id')){
-				layer.eachLayer(function(layer){layer.setStyle({"opacity":1})})
+				layer.eachLayer(function(layer){layer.setStyle({"opacity":1});});
 			}
 		},
 		unselectRoute(e){
@@ -280,7 +282,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
       var coordinates = [];
       coordinates.push(lat);
       coordinates.push(lng);
-      
+
   		this.set('place', selected);
       this.set('pin', coordinates);
       this.transitionToRoute('index', {queryParams: {pin: this.get('pin'), bbox: null}});
@@ -294,7 +296,7 @@ export default Ember.Controller.extend(setTextboxClosed, {
     },
 		searchRepo: function(term) {
       if (Ember.isBlank(term)) { return []; }
-      const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`; 
+      const url = `https://search.mapzen.com/v1/autocomplete?api_key=mapzen-jLrDBSP&text=${term}`;
       return Ember.$.ajax({ url }).then(json => json.features);
     },
     setDisplayStops: function(){
@@ -308,7 +310,6 @@ export default Ember.Controller.extend(setTextboxClosed, {
 						var lat = stops[i].geometry.coordinates[0];
 						var lon = stops[i].geometry.coordinates[1];
 						tempCoord = lat;
-						var coords = stops[i].geometry.coordinates
 						var coordArray = [];
 						coordArray.push(lon);
 						coordArray.push(lat);
@@ -331,13 +332,12 @@ export default Ember.Controller.extend(setTextboxClosed, {
 				var lat = stops[i].geometry.coordinates[0];
 				var lon = stops[i].geometry.coordinates[1];
 				tempCoord = lat;
-				var coords = stops[i].geometry.coordinates
 				var coordArray = [];
 				coordArray.push(lon);
 				coordArray.push(lat);
 				this.model.stopServedByRoutes.features[i].geometry.coordinates = coordArray;
 				this.model.stopServedByRoutes.features[i].icon = L.icon({
-					iconUrl: 'assets/images/stop.png',		
+					iconUrl: 'assets/images/stop.png',
 					iconSize: (10, 10),
 				});
 			}
@@ -351,5 +351,5 @@ export default Ember.Controller.extend(setTextboxClosed, {
     	this.set('routeStopPattern', null);
     }
   }
-	
+
 });

--- a/app/routes/route.js
+++ b/app/routes/route.js
@@ -50,11 +50,12 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
     this.store.unloadAll('data/transitland/operator');
     this.store.unloadAll('data/transitland/stop');
     this.store.unloadAll('data/transitland/route');
-    this.store.unloadAll('data/transitland/route_stop_pattern'); 
+    this.store.unloadAll('data/transitland/route_stop_pattern');
 
     params.total=true;
 
     var routes = this.store.query('data/transitland/route', params);
+    var stops;
 
     if (params.serves){
       // var url = 'https://transit.land/api/v1/stops.geojson?onestop_id=' + params.serves;
@@ -63,15 +64,15 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
       //   routes: routes,
       //   stopServedByRoutes: stopServedByRoutes
       // });
-      var stops = this.store.query('data/transitland/stop', {onestop_id: params.serves});
+      stops = this.store.query('data/transitland/stop', {onestop_id: params.serves});
       return Ember.RSVP.hash({
         routes: routes,
         stops: stops
       });
-      
+
     } else if (params.onestop_id){
       var url = 'https://transit.land/api/v1/stops.geojson?per_page=false&served_by=' + params.onestop_id;
-      var stops = Ember.$.ajax({ url });
+      stops = Ember.$.ajax({ url });
       return Ember.RSVP.hash({
         routes: routes,
         stops: stops
@@ -83,6 +84,6 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
     }
   },
   actions: {
-    
+
   }
 });

--- a/app/stops/controller.js
+++ b/app/stops/controller.js
@@ -1,3 +1,5 @@
+/* global L, moment */
+
 import Ember from 'ember';
 import mapBboxController from 'mobility-playground/mixins/map-bbox-controller';
 import setTextboxClosed from 'mobility-playground/mixins/set-textbox-closed';
@@ -20,7 +22,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
   }),
   place: null,
   icon: L.icon({
-		iconUrl: 'assets/images/marker1.png',		
+		iconUrl: 'assets/images/marker1.png',
 		iconSize: (20, 20),
     iconAnchor: [10, 24],
 	}),
@@ -41,8 +43,6 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
     return this.get('closeTextbox').get('textboxIsClosed');
   }),
   actions: {
-		change(date){
-		},
 		updateLeafletBbox(e) {
 			var leafletBounds = e.target.getBounds();
 			this.set('leafletBbox', leafletBounds.toBBoxString());
@@ -88,7 +88,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
       var coordinates = [];
       coordinates.push(lat);
       coordinates.push(lng);
-      
+
       this.set('place', selected);
       this.set('pin', coordinates);
       this.transitionToRoute('index', {queryParams: {pin: this.get('pin'), bbox: null}});
@@ -143,17 +143,17 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, {
         'Oct' : '10',
         'Nov' : '11',
         'Dec' : '12'
-      }
-      var newDepartureTime = year + "-" + month[monthString] + "-" + day + "T" + hour + ":" + minute
+      };
+      var newDepartureTime = year + "-" + month[monthString] + "-" + day + "T" + hour + ":" + minute;
 
-      // This is the local date and time at the location.  
+      // This is the local date and time at the location.
       // value:
-      // the date and time is specified in ISO 8601 format (YYYY-MM-DDThh:mm) in 
+      // the date and time is specified in ISO 8601 format (YYYY-MM-DDThh:mm) in
       // the local time zone of departure or arrival. For example "2016-07-03T08:06"
-      // ISO 8601 uses the 24-hour clock system. 
-      // A single point in time can be represented by concatenating a complete date expression, 
+      // ISO 8601 uses the 24-hour clock system.
+      // A single point in time can be represented by concatenating a complete date expression,
       // the letter T as a delimiter, and a valid time expression. For example, "2007-04-05T14:30".
-      
+
       this.set('departure_time', newDepartureTime);
     },
     resetDepartureTime: function(){

--- a/app/stops/route.js
+++ b/app/stops/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import mapBboxRoute from 'mobility-playground/mixins/map-bbox-route';
 import setLoading from 'mobility-playground/mixins/set-loading';
-import polygon from 'npm:turf-polygon';
-import difference from 'npm:turf-difference';
 
 export default Ember.Route.extend(mapBboxRoute, setLoading, {
   queryParams: {
@@ -57,19 +55,19 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
     this.store.unloadAll('data/transitland/stop');
     this.store.unloadAll('data/transitland/route');
     this.store.unloadAll('data/transitland/route_stop_pattern');
-    var self = this;
     return this.store.query('data/transitland/stop', params).then(function(stops) {
+      var onlyStop, stopLocation, mode, url;
       if (stops.get('query.isochrone_mode')){
-        var onlyStop = stops.get('firstObject');
-        var stopLocation = onlyStop.get('geometry.coordinates');
-        var url = 'https://matrix.mapzen.com/isochrone?api_key=mapzen-jLrDBSP&json=';
+        onlyStop = stops.get('firstObject');
+        stopLocation = onlyStop.get('geometry.coordinates');
+        url = 'https://matrix.mapzen.com/isochrone?api_key=mapzen-jLrDBSP&json=';
         var linkUrl = 'https://matrix.mapzen.com/isochrone?json=';
-        
-        var mode = stops.get('query.isochrone_mode');
+
+        mode = stops.get('query.isochrone_mode');
         var json = {
           locations: [{"lat":stopLocation[1], "lon":stopLocation[0]}],
           costing: mode,
-          denoise: .3,
+          denoise: 0.3,
           polygons: true,
           generalize: 50,
           costing_options: {"pedestrian":{"use_ferry":0}},
@@ -84,8 +82,8 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
         if (params.departure_time){
           json.date_time = {"type": 1, "value": params.departure_time};
         }
-        url += escape(JSON.stringify(json));
-        linkUrl += escape(JSON.stringify(json));
+        url = encodeURI(url + JSON.stringify(json));
+        linkUrl = encodeURI(linkUrl + JSON.stringify(json));
         return Ember.RSVP.hash({
           stops: stops,
           onlyStop: onlyStop,
@@ -96,13 +94,13 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
           })
         });
       } else {
-        var onlyStop = stops.get('firstObject');
-        var stopLocation = onlyStop.get('geometry.coordinates');
-        var mode = stops.get('query.isochrone_mode');
+        onlyStop = stops.get('firstObject');
+        stopLocation = onlyStop.get('geometry.coordinates');
+        mode = stops.get('query.isochrone_mode');
         var servedBy = stops.get('query.served_by');
         if (servedBy!== null){
           if (servedBy.indexOf('r') === 0) {
-            var url = 'https://transit.land/api/v1/routes.geojson?per_page=false&onestop_id=';
+            url = 'https://transit.land/api/v1/routes.geojson?per_page=false&onestop_id=';
             url += servedBy;
             return Ember.RSVP.hash({
               stops: stops,
@@ -125,7 +123,7 @@ export default Ember.Route.extend(mapBboxRoute, setLoading, {
     });
   },
   actions: {
-    
+
   }
 
 });


### PR DESCRIPTION
This PR cleans up all jshint errors seen when building the application:

* update .jshintrc to allow unused function parameters
* add missing semicolons
* remove unused variables and imports
* remove duplicate functions/keys
* use `global` jshint in files using moment, L
* replace deprecated `escape` function with `encodeURI`
* miscellaneous other jshint errors

Additional Note: I'm using Sublime and have the editorconfig plugin installed (ember-cli projects include a .editorconfig file). It looks like some of the files I opened to make edits to also got a few automatic edits from editorconfig, like cleaning up trailing whitespaces.