### PR TITLE
use comma-separated list on route queries for operated_by

### DIFF
--- a/app/isochrones/controller.js
+++ b/app/isochrones/controller.js
@@ -52,11 +52,6 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
     return true;
   }),
 
-  // operatorIsIncluded: Ember.computed('inlude_operators', function(){
-  //   console.log('operatorIsIncluded');
-  //   return true;
-  // }),
-
   actions: {
     updateLeafletBbox(e) {
       var leafletBounds = e.target.getBounds();
@@ -93,9 +88,6 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
         this.set('isochrone_mode', null);
       } else {
         this.set('isochrone_mode', mode);
-      }
-      if (mode === "multimodal"){
-        // debugger;
       }
     },
     change(date){

--- a/app/isochrones/route.js
+++ b/app/isochrones/route.js
@@ -146,10 +146,16 @@ export default Ember.Route.extend(setLoading, {
       var operators = this.store.query('data/transitland/operator', {bbox: params.bbox});
       var routes;
 
-			if (params.include_operators.length === 1){
-				// change routes query to be only for that operator's routes
-				var operator = params.include_operators[0];
-				routes = this.store.query('data/transitland/route', {bbox: params.bbox, operated_by: operator});
+			if (params.include_operators.length > 0){
+				// change routes query to be only for the selected operator(s) routes
+				var includeOperators = "";
+				for (var j = 0; j < params.include_operators.length; j++){
+					if (j > 0){
+						includeOperators += ","
+					}
+					includeOperators += params.include_operators[j]
+				}
+				routes = this.store.query('data/transitland/route', {bbox: params.bbox, operated_by: includeOperators});
 			} else {
 				routes = this.store.query('data/transitland/route', {bbox: params.bbox});
 			}


### PR DESCRIPTION
…when there is more than one operator included.

closes #299

