### PR TITLE
Stop isochrone#305

### DIFF
--- a/app/isochrones/controller.js
+++ b/app/isochrones/controller.js
@@ -7,7 +7,7 @@ import sharedActions from 'mobility-playground/mixins/shared-actions';
 
 
 export default Ember.Controller.extend(mapBboxController, setTextboxClosed, sharedActions, {
-  queryParams: ['onestop_id', 'isochrone_mode', 'pin', 'departure_time', 'include_operators', 'exclude_operators', 'include_routes', 'exclude_routes'],
+  queryParams: ['onestop_id', 'isochrone_mode', 'pin', 'departure_time', 'include_operators', 'exclude_operators', 'include_routes', 'exclude_routes', 'stop'],
 
   onestop_id: null,
   departure_time: null,
@@ -18,6 +18,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
   exclude_operators: [],
   include_routes: [],
   exclude_routes: [],
+  stop: null,
   
   // this iterates through the arrays for the included and excluded query params, and sets the included or excluded 
   // model attributes for the entities with listed onestopIDs

--- a/app/isochrones/route.js
+++ b/app/isochrones/route.js
@@ -31,6 +31,10 @@ export default Ember.Route.extend(setLoading, {
 		exclude_routes: {
 			replace: true,
 			refreshModel: true
+		},
+		stop: {
+			replace: true,
+			refreshModel: true
 		}
 
 	},

--- a/app/isochrones/template.hbs
+++ b/app/isochrones/template.hbs
@@ -220,53 +220,53 @@
 							{{/if}}
 						</div>
 					{{/if}}
-							</form>
-						</div>
-					</div>
-        </div>
-      </div>
-      <div class="col-xs-12" style="padding-left:0px;">
-      	<button type="button" class="collapse-tab" data-toggle="collapse" data-target="#sidebar-media">&#8597;</button>
-	      {{#if currentlyLoading.isLoading}}<div class="loading-spinner-03"></div>{{/if}}
-	      
-	      <div id={{if currentlyLoading.isLoading 'map-loading' 'map'}}>
-          <div class="location-search" style="width:225px">
-              <div class="row">
-                <div class="ember-basic-dropdown-trigger-icon">
-                  {{#if pin}}
-                   <img src='assets/images/pin_x1.png' class="markerIcon-x" {{action "removePin"}}/>
-                  {{else}}
-                    <img src='assets/images/marker1.png' class="markerIcon"/>
-                  {{/if}}
-                </div>
-                {{#power-select
-                  search=(action "searchRepo")
-                  selected=place
-                  placeholder="Find a place using Mapzen Search..."
-                  onchange=(action "setPlace")
-                  onclose=(action "clearPlace")
-                  as |repo|
-                }}
-                  {{repo.properties.name}}, {{repo.properties.region}}, {{repo.properties.country}}
-                {{/power-select}}
-              </div>
-          </div>
-          	{{#leaflet-map bounds=leafletBounds onMoveend=(action "updateLeafletBbox") onDragend=(action "updateMapMoved") onMouseover=(action "mouseOver") onClick=(action "dropPin")}}
-          	{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution=attribution}}
+					{{#if isochrone_mode}}<br><div>{{url-builder url=model.linkUrl server="Mapzen Mobility" query="results" entity="isochrones" queryParams=queryParams bbox=bbox}}</div>{{/if}}
+				</form>
+			</div>
+		</div>
+  </div>
+</div>
+<div class="col-xs-12" style="padding-left:0px;">
+	<button type="button" class="collapse-tab" data-toggle="collapse" data-target="#sidebar-media">&#8597;</button>
+  {{#if currentlyLoading.isLoading}}<div class="loading-spinner-03"></div>{{/if}}
+  
+  <div id={{if currentlyLoading.isLoading 'map-loading' 'map'}}>
+    <div class="location-search" style="width:225px">
+        <div class="row">
+          <div class="ember-basic-dropdown-trigger-icon">
             {{#if pin}}
-	            {{#if isochrone_mode}}
-							  {{#each model.isochrones.features as |isochrone|}}
-							  	{{#geojson-layer geoJSON=isochrone fillColor=isochrone.properties.fill  stroke=false weight=1 fillOpacity=isochrone.properties.fill-opacity}}
-							  	{{/geojson-layer}}
-						  	{{/each}}
-						  {{/if}}
-              {{#marker-layer location=pinLocation icon=icon draggable=true onDragend=(action "updatePin") onRemove=(action "removePin") riseOnHover=true riseOffset=1000}}
-              {{/marker-layer}}
+             <img src='assets/images/pin_x1.png' class="markerIcon-x" {{action "removePin"}}/>
+            {{else}}
+              <img src='assets/images/marker1.png' class="markerIcon"/>
             {{/if}}
-          {{/leaflet-map}}
-     			
-      	</div>
-  		</div> 
+          </div>
+          {{#power-select
+            search=(action "searchRepo")
+            selected=place
+            placeholder="Find a place using Mapzen Search..."
+            onchange=(action "setPlace")
+            onclose=(action "clearPlace")
+            as |repo|
+          }}
+            {{repo.properties.name}}, {{repo.properties.region}}, {{repo.properties.country}}
+          {{/power-select}}
+        </div>
+    </div>
+  	{{#leaflet-map bounds=leafletBounds onMoveend=(action "updateLeafletBbox") onDragend=(action "updateMapMoved") onMouseover=(action "mouseOver") onClick=(action "dropPin")}}
+  	{{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" attribution=attribution}}
+    {{#if pin}}
+      {{#if isochrone_mode}}
+			  {{#each model.isochrones.features as |isochrone|}}
+			  	{{#geojson-layer geoJSON=isochrone fillColor=isochrone.properties.fill  stroke=false weight=1 fillOpacity=isochrone.properties.fill-opacity}}
+			  	{{/geojson-layer}}
+		  	{{/each}}
+		  {{/if}}
+      {{#marker-layer location=pinLocation icon=icon draggable=true onDragend=(action "updatePin") onRemove=(action "removePin") riseOnHover=true riseOffset=1000}}
+      {{/marker-layer}}
+    {{/if}}
+  {{/leaflet-map}}
+	</div>
+</div> 
 {{else}}
 	<div class="col-md-4 linebreak-text" id="sidebar">
 	<!-- <div class="col-xs-12 col-sm-12 col-md-3 linebreak-text" id="sidebar"> -->

--- a/app/stops/controller.js
+++ b/app/stops/controller.js
@@ -22,11 +22,14 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
   mapMoved: false,
   mousedOver: false,
   stopCoordinates: Ember.computed('onestop_id', function(){
-    console.log('test');
+    var stopLocation = this.model.onlyStop.get('geometry.coordinates');
+    var lat = stopLocation[0];
+    var lng = stopLocation[1];
+    var coordinates = [];
+    coordinates.push(lng);
+    coordinates.push(lat);
+    return coordinates;
   }),
-
-
-  // {{stop.geometry.coordinates}}
   
   actions: {
     updateLeafletBbox(e) {

--- a/app/stops/controller.js
+++ b/app/stops/controller.js
@@ -21,6 +21,12 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
   moment: moment(),
   mapMoved: false,
   mousedOver: false,
+  stopCoordinates: Ember.computed('onestop_id', function(){
+    console.log('test');
+  }),
+
+
+  // {{stop.geometry.coordinates}}
   
   actions: {
     updateLeafletBbox(e) {

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -19,62 +19,11 @@
 								{{#if onestop_id}}
 							  	{{#stop-detail stop=selectedStop bbox=bbox onestop_id=onestop_id stops=model.stops}}{{/stop-detail}}
 							  	<p>{{#link-to 'routes' (query-params serves=onestop_id bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=pin) }}View routes serving this stop{{/link-to}}</p>
-							  	<form>
-							  		<div class="form-group-header">View distance you can travel from this stop via:</div>
-									  <div class="form-group">
-								  		{{#if (eq isochrone_mode "pedestrian")}}
-									  		<input type="radio" id="radio-1" name="options" checked {{action "setIsochroneMode" "pedestrian"}}>
-								  		{{else}}
-								  			<input type="radio" id="radio-1" name="options" {{action "setIsochroneMode" "pedestrian"}}>
-								  		{{/if}}
-									    <label for="radio-1">walking</label><br>
-								  		{{#if (eq isochrone_mode "pedestrian")}}
-								  			{{isochrone-legend isochrone_mode=isochrone_mode}}
-								  		{{/if}}
-										  {{#if (eq isochrone_mode "bicycle")}}
-								  			<input type="radio" id="radio-2" name="options" checked {{action "setIsochroneMode" "bicycle"}}>
-								  		{{else}}
-								  			<input type="radio" id="radio-2" name="options" {{action "setIsochroneMode" "bicycle"}}>
-								  		{{/if}}
-									    <label for="radio-2">biking</label><br>
-								  		{{#if (eq isochrone_mode "bicycle")}}
-								  			{{isochrone-legend isochrone_mode=isochrone_mode}}
-								  		{{/if}}
-								  		{{#if (eq isochrone_mode "auto")}}
-								  			<input type="radio" id="radio-3" name="options" checked {{action "setIsochroneMode" "auto"}}>
-								  		{{else}}
-								  			<input type="radio" id="radio-3" name="options" {{action "setIsochroneMode" "auto"}}>
-								  		{{/if}}
-									    <label for="radio-3">driving</label><br>
-								  		{{#if (eq isochrone_mode "auto")}}
-								  			{{isochrone-legend isochrone_mode=isochrone_mode}}
-								  		{{/if}}
-								  		{{#if (eq isochrone_mode "multimodal")}}
-								  			<input type="radio" id="radio-4" name="options" checked {{action "setIsochroneMode" "multimodal"}}>
-								  		{{else}}
-								  			<input type="radio" id="radio-4" name="options" {{action "setIsochroneMode" "multimodal"}}>
-								  		{{/if}}
-									    <label for="radio-4">transit</label>
-								  		{{#if (eq isochrone_mode "multimodal")}}
-								  			{{isochrone-legend isochrone_mode=isochrone_mode}}
-								  		{{/if}}
-									  </div>
-								  		{{#if (eq isochrone_mode "multimodal")}}
-											  {{#if departure_time}}
-								  		<p class="caption">departure at:</p>
-								  		<div class="datetime-picker">
-								  			{{bs-datetimepicker date=departure_time isTime=true sideBySide=false showTodayButton=true change=(action 'change')}}
-								  		</div>
-								  		<div class="reset-datetime" {{action "resetDepartureTime"}}>
-								  			reset to current date and time <i class="fa fa-undo" aria-hidden="true"></i></div>
-								  	{{else}}
-								  		<p class="caption">departure at:</p>
-								  		<div class="datetime-picker">
-						  			{{bs-datetimepicker date=moment isTime=true sideBySide=false showTodayButton=true change=(action 'change')}}
-						  		</div>
-						  	{{/if}}
-									  	{{/if}}
-									</form>
+							  	{{#if onestop_id}}
+										{{#each model.stops as |stop|}}
+							  			<p>{{#link-to 'isochrones' (query-params serves=null bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=stopCoordinates isochrone_mode="multimodal") }}View isochrones for this stop{{/link-to}}</p>
+							  		{{/each}}
+							  	{{/if}}
 								{{else if served_by}}
 									<form>
 									  <div class="form-group-header">Stops served by:</div>
@@ -107,7 +56,7 @@
 
 				
 				
-				{{#if isochrone_mode}}{{#if onestop_id}}<br><div>{{url-builder url=model.linkUrl server="Mapzen Mobility" query="isochrones" entity="isochrones" queryParams=queryParams bbox=bbox}}</div>{{/if}}{{/if}}
+				
 			</div>
 		  {{#if currentlyLoading.isLoading}}<div class="loading-spinner-03"></div>{{/if}}
 		  <button type="button" class="collapse-tab" data-toggle="collapse" data-target="#sidebar-media">&#8597;</button>
@@ -153,14 +102,6 @@
 						  		{{/marker-layer}}
 					  {{/each}}
 					{{/if}}
-				  {{#if isochrone_mode}}
-				  	{{#if onestop_id}}
-						  {{#each model.isochrones.features as |isochrone|}}
-						  	{{#geojson-layer geoJSON=isochrone fillColor=isochrone.properties.fill  stroke=false weight=1 fillOpacity=isochrone.properties.fill-opacity}}
-						  	{{/geojson-layer}}
-					  	{{/each}}
-					  {{/if}}
-				  {{/if}}
 				  {{#if pin}}
             {{#marker-layer location=pinLocation icon=icon draggable=true riseOnHover=true riseOffset=1000}}
             {{/marker-layer}}
@@ -187,72 +128,12 @@
 		    <div class="expanded-selection">
 					{{#if onestop_id}}
 				  	{{#stop-detail stop=selectedStop bbox=bbox onestop_id=onestop_id stops=model.stops}}{{/stop-detail}}
-
 				  	<p>{{#link-to 'routes' (query-params serves=onestop_id bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=pin) }}View routes serving this stop{{/link-to}}</p>
 				  	{{#if onestop_id}}
 							{{#each model.stops as |stop|}}
-				  			<p>{{#link-to 'isochrones' (query-params serves=null bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=stop.geometry.coordinates) }}View isochrones for this stop{{/link-to}}</p>
+				  			<p>{{#link-to 'isochrones' (query-params serves=null bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=stopCoordinates isochrone_mode="multimodal") }}View isochrones for this stop{{/link-to}}</p>
 				  		{{/each}}
 				  	{{/if}}
-				  	<!-- <form> -->
-							<!-- <div class="isochrone-detail">
-					  		<div class="form-group-header">View distance you can travel from this stop via:</div>
-							  <div class="form-group">
-								  {{#if (eq isochrone_mode "pedestrian")}}
-							  		<input type="radio" id="radio-1" name="options" checked {{action "setIsochroneMode" "pedestrian"}}>
-						  		{{else}}
-						  			<input type="radio" id="radio-1" name="options" {{action "setIsochroneMode" "pedestrian"}}>
-						  		{{/if}}
-							    <label for="radio-1">walking</label><br>
-								  {{#if (eq isochrone_mode "pedestrian")}}
-								  	{{isochrone-legend isochrone_mode=isochrone_mode}}
-						  		{{/if}}
-								  {{#if (eq isochrone_mode "bicycle")}}
-						  			<input type="radio" id="radio-2" name="options" checked {{action "setIsochroneMode" "bicycle"}}>
-						  		{{else}}
-						  			<input type="radio" id="radio-2" name="options" {{action "setIsochroneMode" "bicycle"}}>
-						  		{{/if}}
-							    <label for="radio-2">biking</label><br>
-								  {{#if (eq isochrone_mode "bicycle")}}
-								  	{{isochrone-legend isochrone_mode=isochrone_mode}}
-						  		{{/if}}
-								  
-								  {{#if (eq isochrone_mode "auto")}}
-						  			<input type="radio" id="radio-3" name="options" checked {{action "setIsochroneMode" "auto"}}>
-						  		{{else}}
-						  			<input type="radio" id="radio-4" name="options" {{action "setIsochroneMode" "auto"}}>
-						  		{{/if}}
-							    <label for="radio-3">driving</label><br>
-								  {{#if (eq isochrone_mode "auto")}}
-								  	{{isochrone-legend isochrone_mode=isochrone_mode}}
-						  		{{/if}}
-						  		{{#if (eq isochrone_mode "multimodal")}}
-						  			<input type="radio" id="radio-4" name="options" checked {{action "setIsochroneMode" "multimodal"}}>
-						  		{{else}}
-						  			<input type="radio" id="radio-4" name="options" {{action "setIsochroneMode" "multimodal"}}>
-						  		{{/if}}
-							    <label for="radio-4">transit</label>
-								  {{#if (eq isochrone_mode "multimodal")}}
-								  	{{isochrone-legend isochrone_mode=isochrone_mode}}
-						  		{{/if}}
-							  </div>
-						  	{{#if (eq isochrone_mode "multimodal")}}
-						  		{{#if departure_time}}
-						  		<p class="caption">departure at:</p>
-						  		<div class="datetime-picker">
-						  			{{bs-datetimepicker date=departure_time isTime=true sideBySide=false showTodayButton=true change=(action 'change')}}
-						  		</div>
-						  		<div class="reset-datetime" {{action "resetDepartureTime"}}>
-						  			reset to current date and time <i class="fa fa-undo" aria-hidden="true"></i></div>
-						  	{{else}}
-						  		<p class="caption">departure at:</p>
-						  		<div class="datetime-picker">
-						  			{{bs-datetimepicker date=moment isTime=true sideBySide=false showTodayButton=true change=(action 'change')}}
-						  		</div>
-						  	{{/if}}
-						  	{{/if}}
-						 	</div>
-						</form> -->
 					{{else if served_by}}
 						<form>
 						  <div class="form-group-header">Stops served by:</div>
@@ -283,7 +164,6 @@
 		<div class="btn-group-vertical" role="group" >
   		{{#link-to 'isochrones' (query-params bbox=leafletBbox onestop_id=null served_by=null operated_by=null serves=null style_routes_by=null pin=pin isochrone_mode=null)}}<button class="btn btn-transparent-alt">Generate Isochrones</button>{{/link-to}}
   	</div>	
-		{{#if isochrone_mode}}{{#if onestop_id}}<br><div>{{url-builder url=model.linkUrl server="Mapzen Mobility" query="isochrones" entity="isochrones" queryParams=queryParams bbox=bbox}}</div>{{/if}}{{/if}}
 	</div>
 	<div class="col-md-8">
 	  {{#if currentlyLoading.isLoading}}<div class="loading-spinner-03"></div>{{/if}}
@@ -329,28 +209,6 @@
 					  		{{/marker-layer}}
 				  {{/each}}
 				{{/if}}
-			  <!-- {{#if isochrone_mode}}
-			  	{{#if onestop_id}}
-					  {{#each model.isochrones.features as |isochrone|}}
-				  		{{#if (eq isochrone.properties.contour 60)}}
-					  		{{#geojson-layer geoJSON=isochrone fillColor="#d01c8b" fillOpacity=".2" stroke=false}}
-						  	{{/geojson-layer}}
-						  {{/if}}
-				  		{{#if (eq isochrone.properties.contour 45)}}
-					  		{{#geojson-layer geoJSON=isochrone fillColor="#a3166d"  stroke=false weight=1 fillOpacity=".2"}}
-						  	{{/geojson-layer}}
-						  {{/if}}
-				  		{{#if (eq isochrone.properties.contour 30)}}
-					  		{{#geojson-layer geoJSON=isochrone fillColor="#b8e186" stroke=false weight=1 fillOpacity=".6"}}
-						  	{{/geojson-layer}}
-						  {{/if}}
-				  		{{#if (eq isochrone.properties.contour 15)}}
-					  		{{#geojson-layer geoJSON=isochrone fillColor="#4dac26"  stroke=false weight=1 fillOpacity=".3"}}
-						  	{{/geojson-layer}}
-						  {{/if}}
-						{{/each}}
-				  {{/if}}
-			  {{/if}} -->
 			  {{#if pin}}
           {{#marker-layer location=pinLocation icon=icon draggable=true riseOnHover=true riseOffset=1000}}
           {{/marker-layer}}

--- a/app/stops/template.hbs
+++ b/app/stops/template.hbs
@@ -189,8 +189,13 @@
 				  	{{#stop-detail stop=selectedStop bbox=bbox onestop_id=onestop_id stops=model.stops}}{{/stop-detail}}
 
 				  	<p>{{#link-to 'routes' (query-params serves=onestop_id bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=pin) }}View routes serving this stop{{/link-to}}</p>
-				  	<form>
-							<div class="isochrone-detail">
+				  	{{#if onestop_id}}
+							{{#each model.stops as |stop|}}
+				  			<p>{{#link-to 'isochrones' (query-params serves=null bbox=bbox onestop_id=null served_by=null operated_by=null style_routes_by=null pin=stop.geometry.coordinates) }}View isochrones for this stop{{/link-to}}</p>
+				  		{{/each}}
+				  	{{/if}}
+				  	<!-- <form> -->
+							<!-- <div class="isochrone-detail">
 					  		<div class="form-group-header">View distance you can travel from this stop via:</div>
 							  <div class="form-group">
 								  {{#if (eq isochrone_mode "pedestrian")}}
@@ -247,7 +252,7 @@
 						  	{{/if}}
 						  	{{/if}}
 						 	</div>
-						</form>
+						</form> -->
 					{{else if served_by}}
 						<form>
 						  <div class="form-group-header">Stops served by:</div>
@@ -324,7 +329,7 @@
 					  		{{/marker-layer}}
 				  {{/each}}
 				{{/if}}
-			  {{#if isochrone_mode}}
+			  <!-- {{#if isochrone_mode}}
 			  	{{#if onestop_id}}
 					  {{#each model.isochrones.features as |isochrone|}}
 				  		{{#if (eq isochrone.properties.contour 60)}}
@@ -345,7 +350,7 @@
 						  {{/if}}
 						{{/each}}
 				  {{/if}}
-			  {{/if}}
+			  {{/if}} -->
 			  {{#if pin}}
           {{#marker-layer location=pinLocation icon=icon draggable=true riseOnHover=true riseOffset=1000}}
           {{/marker-layer}}


### PR DESCRIPTION
This changes the UI for viewing isochrones around a stop. Rather than render the isochrone UI within the stop detail view, there is now a link to the isochrones route, using the stop's location to set the pin for isochrone renders.

cc @burritojustice 

closes #305 