### PR TITLE
call speed speed limit

### DIFF
--- a/app/map-matching/controller.js
+++ b/app/map-matching/controller.js
@@ -153,7 +153,7 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
         return "max downward grade: " + attributes.max_downward_grade + "%"; 
       }
     } else {
-      return "speed: " + attributes[selectedAttribute] + " mph";
+      return "speed limit: " + attributes[selectedAttribute] + " mph";
     }
   }),
   segmentAttributes: Ember.computed('selectedSegment', function(){
@@ -335,12 +335,15 @@ export default Ember.Controller.extend(mapBboxController, setTextboxClosed, shar
       this.set('showMapMatch', false);
       this.set('selectedAttribute', null);
       this.set('trace', trace.name);
+      // if (trace.name !== "user_upload"){
+      //   this.set('costing',trace.costing);
+      // }
       if (trace.name === "user_upload"){
         this.set('uploading', true);
       } else {
         this.set('uploading', false);
       }
-      this.set('gpxPlaceholder', trace.display_name)
+      this.set('gpxPlaceholder', trace.display_name);
     },
     setUploading(){
       this.toggleProperty('uploading');

--- a/app/map-matching/template.hbs
+++ b/app/map-matching/template.hbs
@@ -74,13 +74,13 @@
                 <input type="radio" id="grade" name="options" {{action "styleByAttribute" "weighted_grade"}}>
                 <label for="style-attribute">grade</label><br>
               {{/if}}
-              {{#if (eq selectedAttribute "speed")}}
-                <input type="radio" id="speed" name="options" checked {{action "styleByAttribute" "speed"}}>
-                <label for="style-attribute">speed&nbsp;<div class="fa fa-question-circle"></div><br>{{#popover-on-element class="tooltip-on-sidebar" event="click" side="right" duration=3000 spacing=10}}The speed limit is used when one exists. If there is no speed limit information available for a given segment, a default speed value for that classification of road is used.{{/popover-on-element}}<br></label><br>
-              {{else}}
-                <input type="radio" id="speed" name="options" {{action "styleByAttribute" "speed"}}>
-                <label for="style-attribute">speed&nbsp;<div class="fa fa-question-circle"></div><br>{{#popover-on-element class="tooltip-on-sidebar" event="click" side="right" duration=3000 spacing=10}}The speed limit is used when one exists. If there is no speed limit information available for a given segment, a default speed value for that classification of road is used.{{/popover-on-element}}</label><br>
-              {{/if}}
+                {{#if (eq selectedAttribute "speed")}}
+                  <input type="radio" id="speed" name="options" checked {{action "styleByAttribute" "speed"}}>
+                  <label for="style-attribute">speed limit&nbsp;<div class="fa fa-question-circle"></div><br>{{#popover-on-element class="tooltip-on-sidebar" event="click" side="right" duration=3000 spacing=10}}The speed limit is used when one exists. If there is no speed limit information available for a given segment, a default speed value for that classification of road is used.{{/popover-on-element}}<br></label><br>
+                {{else}}
+                  <input type="radio" id="speed" name="options" {{action "styleByAttribute" "speed"}}>
+                  <label for="style-attribute">speed limit&nbsp;<div class="fa fa-question-circle"></div><br>{{#popover-on-element class="tooltip-on-sidebar" event="click" side="right" duration=3000 spacing=10}}The speed limit is used when one exists. If there is no speed limit information available for a given segment, a default speed value for that classification of road is used.{{/popover-on-element}}</label><br>
+                {{/if}}
               {{#if (eq selectedAttribute "speed")}}
                 <table class="legend">
                   <tr><th class="level" style="background-color:#313695;"></th><td>70 mph or more</td></tr>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -764,6 +764,7 @@ td.day.active.today:hover {
   .grade-mid {
     text-align: center;
     padding-top: 5px;
+    padding-left: 20px;
   }
   .grade-high {
     text-align: right;


### PR DESCRIPTION
Still showing speed info for all modes. Calling it "speed limit" (with helper text explaining the fallback), but using the `speed` attribute.

closes #397 